### PR TITLE
Add projectile-wurm collision damage

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "train": "tsc && node dist-train/train.js $@",
-    "test": "vitest",
+    "test": "vitest --run",
     "deploy": "gh-pages -d dist"
   },
   "keywords": [],

--- a/src/ProjectileWurmCollision.test.ts
+++ b/src/ProjectileWurmCollision.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Wurm } from './Wurm.js';
+import { Projectile } from './Projectile.js';
+import { handleProjectileWurmCollision } from './collision.js';
+
+vi.mock('kontra/kontra.mjs', () => ({
+  default: {
+    Sprite: class MockSprite {
+      x: number;
+      y: number;
+      dx: number;
+      dy: number;
+      width: number;
+      height: number;
+      color: string;
+      ddy: number;
+      constructor(properties: any) {
+        Object.assign(this, properties);
+      }
+      advance() {}
+    },
+  },
+}));
+
+describe('handleProjectileWurmCollision', () => {
+  it('damages wurm when projectile collides', () => {
+    const wurm = new Wurm(0, 0, 100, 'blue');
+    const projectile = new Projectile(0, 0, 0, 0, 5, 20, 10);
+    const result = handleProjectileWurmCollision(projectile, wurm);
+    expect(result).toBe(true);
+    expect(wurm.health).toBe(80);
+  });
+
+  it('returns false when no collision occurs', () => {
+    const wurm = new Wurm(100, 100, 100, 'blue');
+    const projectile = new Projectile(0, 0, 0, 0, 5, 20, 10);
+    const result = handleProjectileWurmCollision(projectile, wurm);
+    expect(result).toBe(false);
+    expect(wurm.health).toBe(100);
+  });
+});

--- a/src/ProjectileWurmCollision.test.ts
+++ b/src/ProjectileWurmCollision.test.ts
@@ -23,19 +23,23 @@ vi.mock('kontra/kontra.mjs', () => ({
 }));
 
 describe('handleProjectileWurmCollision', () => {
-  it('damages wurm when projectile collides', () => {
+  it('damages wurm and destroys terrain when projectile collides', () => {
     const wurm = new Wurm(0, 0, 100, 'blue');
     const projectile = new Projectile(0, 0, 0, 0, 5, 20, 10);
-    const result = handleProjectileWurmCollision(projectile, wurm);
+    const terrain = { destroy: vi.fn() } as any;
+    const result = handleProjectileWurmCollision(projectile, wurm, terrain);
     expect(result).toBe(true);
     expect(wurm.health).toBe(80);
+    expect(terrain.destroy).toHaveBeenCalledWith(0, 0, 10);
   });
 
   it('returns false when no collision occurs', () => {
     const wurm = new Wurm(100, 100, 100, 'blue');
     const projectile = new Projectile(0, 0, 0, 0, 5, 20, 10);
-    const result = handleProjectileWurmCollision(projectile, wurm);
+    const terrain = { destroy: vi.fn() } as any;
+    const result = handleProjectileWurmCollision(projectile, wurm, terrain);
     expect(result).toBe(false);
     expect(wurm.health).toBe(100);
+    expect(terrain.destroy).not.toHaveBeenCalled();
   });
 });

--- a/src/collision.ts
+++ b/src/collision.ts
@@ -1,9 +1,15 @@
 import { Projectile } from './Projectile.js';
 import { Wurm } from './Wurm.js';
+import { Terrain } from './Terrain.js';
 
-export function handleProjectileWurmCollision(projectile: Projectile, wurm: Wurm): boolean {
+export function handleProjectileWurmCollision(
+  projectile: Projectile,
+  wurm: Wurm,
+  terrain: Terrain
+): boolean {
   if (wurm.collidesWith(projectile)) {
     wurm.takeDamage(projectile.damage);
+    terrain.destroy(projectile.x, projectile.y, projectile.explosionRadius);
     return true;
   }
   return false;

--- a/src/collision.ts
+++ b/src/collision.ts
@@ -1,0 +1,10 @@
+import { Projectile } from './Projectile.js';
+import { Wurm } from './Wurm.js';
+
+export function handleProjectileWurmCollision(projectile: Projectile, wurm: Wurm): boolean {
+  if (wurm.collidesWith(projectile)) {
+    wurm.takeDamage(projectile.damage);
+    return true;
+  }
+  return false;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -147,7 +147,7 @@ function startGame() {
             const projectile = projectiles[i];
             projectile.update();
 
-            if (handleProjectileWurmCollision(projectile, playerWurm)) {
+            if (handleProjectileWurmCollision(projectile, playerWurm, terrain)) {
               projectiles.splice(i, 1);
               const indexInCurrentTurn = currentTurnProjectiles.indexOf(projectile);
               if (indexInCurrentTurn > -1) {
@@ -158,7 +158,7 @@ function startGame() {
               continue;
             }
 
-            if (handleProjectileWurmCollision(projectile, aiWurm)) {
+            if (handleProjectileWurmCollision(projectile, aiWurm, terrain)) {
               projectiles.splice(i, 1);
               const indexInCurrentTurn = currentTurnProjectiles.indexOf(projectile);
               if (indexInCurrentTurn > -1) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import { getObservation } from './ai/ObservationSpace.js';
 import { WEAPON_CHOICES } from './ai/ActionSpace.js';
 import { weaponProperties } from './WeaponProperties.js';
 import { SoundManager } from './SoundManager.js';
+import { handleProjectileWurmCollision } from "./collision.js";
 
 // Sound Manager
 const soundManager = new SoundManager();
@@ -145,6 +146,28 @@ function startGame() {
           for (let i = projectiles.length - 1; i >= 0; i--) {
             const projectile = projectiles[i];
             projectile.update();
+
+            if (handleProjectileWurmCollision(projectile, playerWurm)) {
+              projectiles.splice(i, 1);
+              const indexInCurrentTurn = currentTurnProjectiles.indexOf(projectile);
+              if (indexInCurrentTurn > -1) {
+                currentTurnProjectiles.splice(indexInCurrentTurn, 1);
+              }
+              soundManager.playSound('explosion');
+              soundManager.playSound('damage');
+              continue;
+            }
+
+            if (handleProjectileWurmCollision(projectile, aiWurm)) {
+              projectiles.splice(i, 1);
+              const indexInCurrentTurn = currentTurnProjectiles.indexOf(projectile);
+              if (indexInCurrentTurn > -1) {
+                currentTurnProjectiles.splice(indexInCurrentTurn, 1);
+              }
+              soundManager.playSound('explosion');
+              soundManager.playSound('damage');
+              continue;
+            }
 
             // Check collision with terrain
             if (terrain.isColliding(projectile.x + projectile.radius, projectile.y + projectile.radius)) {

--- a/src/train.ts
+++ b/src/train.ts
@@ -11,6 +11,7 @@ import { getObservation } from './ai/ObservationSpace.js';
 import { WEAPON_CHOICES } from './ai/ActionSpace.js';
 import { weaponProperties } from './WeaponProperties.js';
 import { calculateReward } from './ai/RewardFunction.js';
+import { handleProjectileWurmCollision } from "./collision.js";
 
 // Setup JSDOM for Kontra.js headless environment
 const dom = new JSDOM(`<!DOCTYPE html><body><canvas id="game"></canvas></body>`);
@@ -108,6 +109,18 @@ async function train() {
         for (let i = projectiles.length - 1; i >= 0; i--) {
           const p = projectiles[i];
           p.update();
+
+          if (handleProjectileWurmCollision(p, playerWurm)) {
+            console.log(`Player Wurm took damage. Health: ${playerWurm.health}`);
+            projectiles.splice(i, 1);
+            continue;
+          }
+
+          if (handleProjectileWurmCollision(p, aiWurm)) {
+            console.log(`AI Wurm took damage. Health: ${aiWurm.health}`);
+            projectiles.splice(i, 1);
+            continue;
+          }
 
           if (terrain.isColliding(p.x, p.y)) {
             console.log(`Projectile collided with terrain at x=${p.x}, y=${p.y}!`);

--- a/src/train.ts
+++ b/src/train.ts
@@ -110,13 +110,13 @@ async function train() {
           const p = projectiles[i];
           p.update();
 
-          if (handleProjectileWurmCollision(p, playerWurm)) {
+          if (handleProjectileWurmCollision(p, playerWurm, terrain)) {
             console.log(`Player Wurm took damage. Health: ${playerWurm.health}`);
             projectiles.splice(i, 1);
             continue;
           }
 
-          if (handleProjectileWurmCollision(p, aiWurm)) {
+          if (handleProjectileWurmCollision(p, aiWurm, terrain)) {
             console.log(`AI Wurm took damage. Health: ${aiWurm.health}`);
             projectiles.splice(i, 1);
             continue;


### PR DESCRIPTION
## Summary
- handle projectile and wurm collisions in a dedicated util
- damage wurms and remove projectiles on direct collision
- update game and training loops to use the new collision logic
- test projectile-wurm collision behaviour

## Testing
- `npx vitest run`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68812e1d85288323b2cc5e17837c688c