### PR TITLE
Refactor: centralize game logic

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -1,0 +1,115 @@
+import kontra from 'kontra/kontra.mjs';
+const { init } = kontra;
+import { Terrain } from './Terrain.js';
+import { Projectile } from './Projectile.js';
+import { Wurm } from './Wurm.js';
+import { weaponProperties } from './WeaponProperties.js';
+import { handleProjectileWurmCollision } from './collision.js';
+
+export class Game {
+  public terrain: Terrain;
+  public playerWurm: Wurm;
+  public aiWurm: Wurm;
+  public projectiles: Projectile[] = [];
+  public currentTurnProjectiles: Projectile[] = [];
+  private canvas: HTMLCanvasElement;
+  private context: CanvasRenderingContext2D;
+
+  constructor(canvas: HTMLCanvasElement, context: CanvasRenderingContext2D) {
+    this.canvas = canvas;
+    this.context = context;
+    init(canvas);
+    this.terrain = new Terrain(canvas.width, canvas.height, context);
+    this.playerWurm = new Wurm(100, this.terrain.getGroundHeight(100), 100, 'blue');
+    this.aiWurm = new Wurm(canvas.width - 100, this.terrain.getGroundHeight(canvas.width - 100), 100, 'green');
+  }
+
+  public reset() {
+    this.terrain = new Terrain(this.canvas.width, this.canvas.height, this.context);
+    this.playerWurm.x = 100;
+    this.playerWurm.y = this.terrain.getGroundHeight(100) - this.playerWurm.height;
+    this.playerWurm.health = 100;
+    this.aiWurm.x = this.canvas.width - 100;
+    this.aiWurm.y = this.terrain.getGroundHeight(this.canvas.width - 100) - this.aiWurm.height;
+    this.aiWurm.health = 100;
+    this.projectiles = [];
+    this.currentTurnProjectiles = [];
+  }
+
+  public fire(wurm: Wurm, weapon: string, angle: number, power: number) {
+    const { radius, damage, explosionRadius } = weaponProperties[weapon];
+    const radians = angle * Math.PI / 180;
+    const startX = wurm.x + wurm.width / 2 + Math.cos(radians) * radius - radius;
+    const startY = wurm.y + wurm.height / 2 - Math.sin(radians) * radius - radius;
+    const velX = power * Math.cos(radians) * 0.15;
+    const velY = power * Math.sin(radians) * -0.15;
+
+    const projectile = new Projectile(startX, startY, velX, velY, radius, damage, explosionRadius);
+    this.projectiles.push(projectile);
+    this.currentTurnProjectiles.push(projectile);
+    return projectile;
+  }
+
+  private removeFromCurrent(projectile: Projectile) {
+    const idx = this.currentTurnProjectiles.indexOf(projectile);
+    if (idx > -1) {
+      this.currentTurnProjectiles.splice(idx, 1);
+    }
+  }
+
+  public update() {
+    this.playerWurm.update(this.terrain);
+    this.aiWurm.update(this.terrain);
+    for (let i = this.projectiles.length - 1; i >= 0; i--) {
+      const projectile = this.projectiles[i];
+      projectile.update();
+      if (handleProjectileWurmCollision(projectile, this.playerWurm, this.terrain)) {
+        this.projectiles.splice(i, 1);
+        this.removeFromCurrent(projectile);
+        continue;
+      }
+      if (handleProjectileWurmCollision(projectile, this.aiWurm, this.terrain)) {
+        this.projectiles.splice(i, 1);
+        this.removeFromCurrent(projectile);
+        continue;
+      }
+      if (this.terrain.isColliding(projectile.x + projectile.radius, projectile.y + projectile.radius)) {
+        this.terrain.destroy(projectile.x + projectile.radius, projectile.y + projectile.radius, projectile.explosionRadius);
+        this.projectiles.splice(i, 1);
+        this.removeFromCurrent(projectile);
+        if (this.playerWurm.collidesWith(projectile)) {
+          this.playerWurm.takeDamage(projectile.damage);
+        }
+        if (this.aiWurm.collidesWith(projectile)) {
+          this.aiWurm.takeDamage(projectile.damage);
+        }
+      } else if (
+        projectile.x + projectile.radius * 2 < 0 ||
+        projectile.x > this.canvas.width ||
+        projectile.y + projectile.radius * 2 < 0 ||
+        projectile.y > this.canvas.height
+      ) {
+        this.projectiles.splice(i, 1);
+        this.removeFromCurrent(projectile);
+      }
+    }
+  }
+
+  public simulateUntilProjectilesResolve(maxIterations = 5000) {
+    let iterations = 0;
+    while (this.currentTurnProjectiles.length > 0 && iterations < maxIterations) {
+      this.update();
+      iterations++;
+    }
+  }
+
+  public draw() {
+    this.terrain.draw();
+    this.playerWurm.draw();
+    this.aiWurm.draw();
+    for (const projectile of this.projectiles) {
+      projectile.render();
+    }
+  }
+}
+

--- a/src/Wurm.ts
+++ b/src/Wurm.ts
@@ -41,14 +41,16 @@ export class Wurm extends Sprite {
     return distance < this.width / 2 + projectile.radius;
   }
 
-  public update = (terrain: any) => {
-    const belowX = Math.floor(this.x + this.width / 2);
-    const belowY = Math.floor(this.y + this.height + 1);
-    if (!terrain.isColliding(belowX, belowY)) {
-      this.dy += 0.2;
-      this.y += this.dy;
-    } else {
-      this.dy = 0;
+  public update = (terrain?: any) => {
+    if (terrain) {
+      const belowX = Math.floor(this.x + this.width / 2);
+      const belowY = Math.floor(this.y + this.height + 1);
+      if (!terrain.isColliding(belowX, belowY)) {
+        this.dy += 0.2;
+        this.y += this.dy;
+      } else {
+        this.dy = 0;
+      }
     }
   }
 }

--- a/src/train.ts
+++ b/src/train.ts
@@ -3,15 +3,11 @@ import * as tf from '@tensorflow/tfjs-core';
 import '@tensorflow/tfjs-node'; // Use tfjs-node for headless environment
 
 import { init } from './kontra.mock.js';
-import { Terrain } from './Terrain.js';
-import { Projectile } from './Projectile.js';
-import { Wurm } from './Wurm.js';
+import { Game } from './Game.js';
 import { DQNModel } from './ai/DQNModel.js';
 import { getObservation } from './ai/ObservationSpace.js';
 import { WEAPON_CHOICES } from './ai/ActionSpace.js';
-import { weaponProperties } from './WeaponProperties.js';
 import { calculateReward } from './ai/RewardFunction.js';
-import { handleProjectileWurmCollision } from "./collision.js";
 
 // Setup JSDOM for Kontra.js headless environment
 const dom = new JSDOM(`<!DOCTYPE html><body><canvas id="game"></canvas></body>`);
@@ -26,11 +22,9 @@ canvas.height = 600;
 
 init(canvas);
 
-// Game setup (similar to main.ts)
-let terrain = new Terrain(canvas.width, canvas.height, canvas.getContext('2d')!);
-const playerWurm = new Wurm(100, 100, 100, 'blue');
-const aiWurm = new Wurm(canvas.width - 100, 100, 100, 'green');
-const projectiles: Projectile[] = [];
+// Game setup using shared Game class
+const game = new Game(canvas, canvas.getContext('2d')!);
+const { playerWurm, aiWurm, terrain } = game;
 
 // DQN Model setup
 const observationSpaceSize = 6 + (canvas.width / 20); // 6 for wurm data + terrain heights
@@ -46,12 +40,7 @@ let epsilon = 1.0; // Exploration-exploitation trade-off
 async function train() {
   for (let episode = 0; episode < numEpisodes; episode++) {
     // Reset game state for new episode
-    playerWurm.health = 100;
-    aiWurm.health = 100;
-    projectiles.length = 0;
-    // Regenerate terrain for variety
-    terrain = new Terrain(canvas.width, canvas.height, canvas.getContext('2d')!); 
-    terrain.draw();
+    game.reset();
 
     let done = false;
     let totalReward = 0;
@@ -77,80 +66,14 @@ async function train() {
       const angle = angleBin * 18; // 0-180 in 10 bins
       const power = powerBin * 10; // 0-100 in 10 bins
 
-      // Simulate action (fire projectile)
-      const weaponName = WEAPON_CHOICES[weaponIdx];
-      const { radius, damage, explosionRadius } = weaponProperties[weaponName];
-
-      const radians = angle * Math.PI / 180;
-      const startX = playerWurm.x + playerWurm.width / 2 + Math.cos(radians) * radius - radius;
-      const startY = playerWurm.y + playerWurm.height / 2 - Math.sin(radians) * radius - radius;
-      const velX = power * Math.cos(radians) * 0.15;
-      const velY = power * Math.sin(radians) * -0.15;
-
-      const projectile = new Projectile(
-        startX,
-        startY,
-        velX,
-        velY,
-        radius,
-        damage,
-        explosionRadius
-      );
-      projectiles.push(projectile);
-      console.log(`Projectile created: x=${startX}, y=${startY}, velX=${velX}, velY=${velY}`);
-
-      // Simulate game loop update until projectiles resolve
-      let allProjectilesResolved = false;
-      let simulationIterations = 0;
-      const MAX_SIMULATION_ITERATIONS = 5000; // Safeguard to prevent infinite loops
-
-      while (!allProjectilesResolved && simulationIterations < MAX_SIMULATION_ITERATIONS) {
-        allProjectilesResolved = true;
-        for (let i = projectiles.length - 1; i >= 0; i--) {
-          const p = projectiles[i];
-          p.update();
-
-          if (handleProjectileWurmCollision(p, playerWurm, terrain)) {
-            console.log(`Player Wurm took damage. Health: ${playerWurm.health}`);
-            projectiles.splice(i, 1);
-            continue;
-          }
-
-          if (handleProjectileWurmCollision(p, aiWurm, terrain)) {
-            console.log(`AI Wurm took damage. Health: ${aiWurm.health}`);
-            projectiles.splice(i, 1);
-            continue;
-          }
-
-          if (terrain.isColliding(p.x, p.y)) {
-            console.log(`Projectile collided with terrain at x=${p.x}, y=${p.y}!`);
-            terrain.destroy(p.x, p.y, p.explosionRadius);
-            projectiles.splice(i, 1);
-            // Apply damage to wurms
-            if (playerWurm.collidesWith(p)) {
-              playerWurm.takeDamage(p.damage);
-              console.log(`Player Wurm took damage. Health: ${playerWurm.health}`);
-            }
-            if (aiWurm.collidesWith(p as any)) {
-              aiWurm.takeDamage(p.damage);
-              console.log(`AI Wurm took damage. Health: ${aiWurm.health}`);
-            }
-          } else if (p.x < 0 || p.x > canvas.width || p.y > canvas.height) {
-            console.log(`Projectile went off-screen at x=${p.x}, y=${p.y}.`);
-            projectiles.splice(i, 1);
-          } else {
-            allProjectilesResolved = false;
-          }
-        }
-        simulationIterations++;
-        if (!allProjectilesResolved && simulationIterations >= MAX_SIMULATION_ITERATIONS) {
-          console.log(`Simulation reached MAX_SIMULATION_ITERATIONS (${MAX_SIMULATION_ITERATIONS}). Projectiles remaining: ${projectiles.length}`);
-        }
-      }
-
-      // Determine next state and reward
       const prevPlayerHealth = playerWurm.health;
       const prevAiHealth = aiWurm.health;
+
+      const weaponName = WEAPON_CHOICES[weaponIdx];
+      game.fire(playerWurm, weaponName, angle, power);
+      game.simulateUntilProjectilesResolve();
+
+      // Determine next state and reward
 
       // Apply damage to wurms (already done in the projectile loop)
 
@@ -168,7 +91,7 @@ async function train() {
       targetArray[actionIndex] = reward;
       const target = tf.tensor2d([targetArray], [1, actionSpaceSize]);
       await dqnModel.train(observation, target);
-      if (gameEnded || simulationIterations >= MAX_SIMULATION_ITERATIONS || numEpisodes > episode) {
+      if (gameEnded) {
         done = true;
       }
     }


### PR DESCRIPTION
## Summary
- add `Game` class with shared update logic
- refactor training script to use `Game`
- update main game loop to rely on `Game`
- adjust `Wurm` update signature for compatibility

## Testing
- `npm run build`
- `npm test`
- `npx tsc`

------
https://chatgpt.com/codex/tasks/task_e_68813b2625688323a32717ee380eae2c