### PR TITLE
Fix AI model load path

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -64,7 +64,7 @@ function startGame() {
 
   async function loadModel() {
     try {
-      aiModel = await DQNModel.load('/src/models/dqn-model');
+      aiModel = await DQNModel.load('/models/dqn-model/model.json');
       console.log('AI Model loaded successfully.');
     } catch (error) {
       console.warn('Could not load AI model, using random AI.', error);

--- a/src/train.ts
+++ b/src/train.ts
@@ -100,8 +100,8 @@ async function train() {
     console.log(`Episode ${episode + 1}: Total Reward = ${totalReward}, Epsilon = ${epsilon.toFixed(2)}`);
   }
 
-  // Save the trained model
-  await dqnModel.save('file://./src/models/dqn-model');
+  // Save the trained model to the public directory so it can be served
+  await dqnModel.save('file://./public/models/dqn-model');
   console.log('Model trained and saved.');
 }
 


### PR DESCRIPTION
## Summary
- update training script to save model to `public/models`
- load AI model from `/models/dqn-model/model.json`

## Testing
- `npm test`
- `npm run train 1`

------
https://chatgpt.com/codex/tasks/task_e_68814118c2348323b93b99b88e3986b4