### PR TITLE
Fix bazooka spawn hurting shooter

### DIFF
--- a/src/Game.test.ts
+++ b/src/Game.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Game } from './Game.js';
+import { Wurm } from './Wurm.js';
+
+vi.mock('kontra/kontra.mjs', () => ({
+  default: {
+    Sprite: class MockSprite {
+      x: number;
+      y: number;
+      width: number;
+      height: number;
+      dx: number;
+      dy: number;
+      color: string;
+      context: any;
+      constructor(props: any) {
+        Object.assign(this, props);
+        this.dx = props.dx || 0;
+        this.dy = props.dy || 0;
+        this.context = props.context || {
+          drawImage: () => {},
+          fillStyle: '',
+          fillRect: () => {},
+          getImageData: () => ({ data: [0, 0, 0, 0] }),
+          globalCompositeOperation: '',
+          beginPath: () => {},
+          arc: () => {},
+          fill: () => {},
+        };
+      }
+      advance() {
+        this.x += this.dx;
+        this.y += this.dy;
+      }
+    },
+    GameObject: class MockGameObject {
+      x: number;
+      y: number;
+      width: number;
+      height: number;
+      context: any;
+      constructor(props: any) {
+        Object.assign(this, props);
+        this.context = props.context || {
+          drawImage: () => {},
+          fillStyle: '',
+          fillRect: () => {},
+          getImageData: () => ({ data: [0, 0, 0, 0] }),
+          globalCompositeOperation: '',
+          beginPath: () => {},
+          arc: () => {},
+          fill: () => {},
+        };
+      }
+    },
+    init: () => {},
+  }
+}));
+
+describe('Game.fire', () => {
+  it('spawns projectile outside the firing wurm', () => {
+    const canvas = document.createElement('canvas');
+    canvas.width = 200;
+    canvas.height = 200;
+    const context = canvas.getContext('2d') as CanvasRenderingContext2D;
+    const game = new Game(canvas, context);
+
+    const projectile = game.fire(game.playerWurm, 'bazooka', 45, 50);
+
+    expect(game.playerWurm.collidesWith(projectile)).toBe(false);
+  });
+});

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -39,8 +39,11 @@ export class Game {
   public fire(wurm: Wurm, weapon: string, angle: number, power: number) {
     const { radius, damage, explosionRadius } = weaponProperties[weapon];
     const radians = angle * Math.PI / 180;
-    const startX = wurm.x + wurm.width / 2 + Math.cos(radians) * radius - radius;
-    const startY = wurm.y + wurm.height / 2 - Math.sin(radians) * radius - radius;
+    const offset = wurm.width / 2 + radius + 1;
+    const startX =
+      wurm.x + wurm.width / 2 + Math.cos(radians) * offset - radius;
+    const startY =
+      wurm.y + wurm.height / 2 - Math.sin(radians) * offset - radius;
     const velX = power * Math.cos(radians) * 0.15;
     const velY = power * Math.sin(radians) * -0.15;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -222,8 +222,9 @@ const aiDemoLoop = GameLoop({
       const { radius, damage, explosionRadius } = weaponProperties[aiWeapon];
 
       const radians = aiAngle * Math.PI / 180;
-      const startX = aiDemoWurm1.x + aiDemoWurm1.width / 2 + Math.cos(radians) * radius - radius;
-      const startY = aiDemoWurm1.y + aiDemoWurm1.height / 2 - Math.sin(radians) * radius - radius;
+      const offset = aiDemoWurm1.width / 2 + radius + 1;
+      const startX = aiDemoWurm1.x + aiDemoWurm1.width / 2 + Math.cos(radians) * offset - radius;
+      const startY = aiDemoWurm1.y + aiDemoWurm1.height / 2 - Math.sin(radians) * offset - radius;
       const velX = aiPower * Math.cos(radians) * 0.15;
       const velY = aiPower * Math.sin(radians) * -0.15;
 


### PR DESCRIPTION
## Summary
- prevent projectiles from spawning inside the firing wurm
- update AI demo firing logic accordingly
- add regression test for `Game.fire`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68814c5612f48323bc286d2892ead933