### PR TITLE
Reuse canvas for demo and game

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,16 +8,13 @@
     <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
   </head>
   <body>
+    <canvas id="game"></canvas>
     <div id="start-screen">
       <h1>Wurms</h1>
       <button id="start-game-button">Start Game</button>
-      <div id="ai-demo-canvas-container">
-        <!-- AI vs AI demo will be rendered here -->
-      </div>
     </div>
 
     <div id="game-screen" style="display: none;">
-      <canvas id="game"></canvas>
       <div id="controls">
         <label for="weapon">Weapon:</label>
         <select id="weapon">

--- a/src/main.ts
+++ b/src/main.ts
@@ -194,20 +194,33 @@ function startGame() {
   mainGameLoop.start();
 }
 
-// AI vs AI Demo Loop
-const aiDemoCanvasContainer = document.getElementById('ai-demo-canvas-container') as HTMLElement;
-const aiDemoCanvas = document.createElement('canvas');
+// AI vs AI Demo Loop on the main canvas
+const aiDemoCanvas = document.getElementById('game') as HTMLCanvasElement;
 aiDemoCanvas.width = 800;
 aiDemoCanvas.height = 600;
-aiDemoCanvasContainer.appendChild(aiDemoCanvas);
+
+const aiDemoContext = aiDemoCanvas.getContext('2d') as CanvasRenderingContext2D;
 
 init(aiDemoCanvas);
 
-const aiDemoTerrain = new Terrain(aiDemoCanvas.width, aiDemoCanvas.height, aiDemoCanvas.getContext('2d')!);
-const aiDemoWurm1 = new Wurm(50, aiDemoTerrain.getGroundHeight(50), 100, 'red');
-const aiDemoWurm2 = new Wurm(aiDemoCanvas.width - 50, aiDemoTerrain.getGroundHeight(aiDemoCanvas.width - 50), 100, 'yellow');
-const aiDemoProjectiles: Projectile[] = [];
+let aiDemoTerrain: Terrain;
+let aiDemoWurm1: Wurm;
+let aiDemoWurm2: Wurm;
+let aiDemoProjectiles: Projectile[] = [];
 let aiDemoTurn: 'wurm1' | 'wurm2' = 'wurm1';
+
+function initAiDemo() {
+  aiDemoTerrain = new Terrain(aiDemoCanvas.width, aiDemoCanvas.height, aiDemoContext);
+  aiDemoWurm1 = new Wurm(50, aiDemoTerrain.getGroundHeight(50), 100, 'red');
+  aiDemoWurm2 = new Wurm(
+    aiDemoCanvas.width - 50,
+    aiDemoTerrain.getGroundHeight(aiDemoCanvas.width - 50),
+    100,
+    'yellow'
+  );
+  aiDemoProjectiles = [];
+  aiDemoTurn = 'wurm1';
+}
 
 const aiDemoLoop = GameLoop({
   update: () => {
@@ -275,6 +288,7 @@ startGameButton.addEventListener('click', () => {
   startScreen.style.display = 'none';
   gameScreen.style.display = 'block';
   aiDemoLoop.stop(); // Stop AI demo when game starts
+  aiDemoContext.clearRect(0, 0, aiDemoCanvas.width, aiDemoCanvas.height);
   startGame(); // Start main game loop
 });
 
@@ -282,9 +296,11 @@ startGameButton.addEventListener('click', () => {
 playAgainButton.addEventListener('click', () => {
   gameOverScreen.style.display = 'none';
   startScreen.style.display = 'flex';
+  initAiDemo();
   aiDemoLoop.start(); // Restart AI demo
 });
 
+initAiDemo();
 aiDemoLoop.start(); // Start AI demo loop initially
 
 

--- a/src/style.css
+++ b/src/style.css
@@ -97,21 +97,6 @@ canvas {
   background-color: #0056b3;
 }
 
-#ai-demo-canvas-container {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  z-index: -1; /* Send to back */
-  opacity: 0.3; /* Make it subtle */
-}
-
-#ai-demo-canvas-container canvas {
-  width: 100%;
-  height: 100%;
-  object-fit: contain;
-}
 
 #game-over-screen {
   position: absolute;


### PR DESCRIPTION
## Summary
- display a single canvas element used by both the AI vs AI demo and the main game
- remove unused AI demo canvas container styles
- reset the AI demo loop when returning to the start screen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68814d63fc7083238366881e3e8607b1