### PR TITLE
Fix projectile spawn hitting player

### DIFF
--- a/src/Game.test.ts
+++ b/src/Game.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Game } from './Game.js';
+
+vi.mock('kontra/kontra.mjs', async () => {
+  const mod = await import('./kontra.mock.js');
+  return { default: { Sprite: mod.MockSprite, GameObject: mod.MockGameObject, init: mod.init } };
+});
+
+describe('Game projectile spawning', () => {
+  it('does not damage the player when firing bazooka at 45 deg with power 50', () => {
+    const canvas = document.createElement('canvas');
+    canvas.width = 800;
+    canvas.height = 600;
+    const ctx = canvas.getContext('2d')!;
+    const game = new Game(canvas, ctx);
+    game.fire(game.playerWurm, 'bazooka', 45, 50);
+    game.update();
+    expect(game.playerWurm.health).toBe(100);
+  });
+});

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -39,8 +39,9 @@ export class Game {
   public fire(wurm: Wurm, weapon: string, angle: number, power: number) {
     const { radius, damage, explosionRadius } = weaponProperties[weapon];
     const radians = angle * Math.PI / 180;
-    const startX = wurm.x + wurm.width / 2 + Math.cos(radians) * radius - radius;
-    const startY = wurm.y + wurm.height / 2 - Math.sin(radians) * radius - radius;
+    const offset = wurm.width / 2 + radius + 0.1;
+    const startX = wurm.x + wurm.width / 2 + Math.cos(radians) * offset - radius;
+    const startY = wurm.y + wurm.height / 2 - Math.sin(radians) * offset - radius;
     const velX = power * Math.cos(radians) * 0.15;
     const velY = power * Math.sin(radians) * -0.15;
 


### PR DESCRIPTION
## Summary
- adjust projectile offset when firing so it spawns outside the wurm
- add test ensuring bazooka doesn't damage the firing wurm

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68814f8f4cc48323bdd70dc1d599f9d0