### PR TITLE
Allow projectiles to exit top of canvas

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -89,7 +89,6 @@ export class Game {
       } else if (
         projectile.x + projectile.radius * 2 < 0 ||
         projectile.x > this.canvas.width ||
-        projectile.y + projectile.radius * 2 < 0 ||
         projectile.y > this.canvas.height
       ) {
         this.projectiles.splice(i, 1);

--- a/src/GameTopProjectile.test.ts
+++ b/src/GameTopProjectile.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Game } from './Game.js';
+import { Projectile } from './Projectile.js';
+
+vi.mock('kontra/kontra.mjs', async () => {
+  const mod = await import('./kontra.mock.js');
+  return { default: { Sprite: mod.MockSprite, GameObject: mod.MockGameObject, init: mod.init } };
+});
+
+describe('Projectile top boundary behavior', () => {
+  it('retains projectiles that exit the top but stay within horizontal bounds', () => {
+    const canvas = document.createElement('canvas');
+    canvas.width = 800;
+    canvas.height = 600;
+    const ctx = canvas.getContext('2d')!;
+    const game = new Game(canvas, ctx);
+
+    const projectile = new Projectile(200, -6, 0, 0, 5, 0, 0);
+    game.projectiles.push(projectile);
+    game.currentTurnProjectiles.push(projectile);
+
+    game.update();
+
+    expect(game.projectiles.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- permit projectiles to leave the top of the canvas while within left/right bounds
- add regression test to ensure projectiles above canvas aren't removed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688155d3682c832399d51501beabae90