### PR TITLE
Bounce projectiles off sides

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -64,6 +64,13 @@ export class Game {
     for (let i = this.projectiles.length - 1; i >= 0; i--) {
       const projectile = this.projectiles[i];
       projectile.update();
+      if (projectile.x < 0) {
+        projectile.x = 0;
+        projectile.dx = -projectile.dx;
+      } else if (projectile.x + projectile.radius * 2 > this.canvas.width) {
+        projectile.x = this.canvas.width - projectile.radius * 2;
+        projectile.dx = -projectile.dx;
+      }
       if (handleProjectileWurmCollision(projectile, this.playerWurm, this.terrain)) {
         console.log('Player hit!');
         this.projectiles.splice(i, 1);

--- a/src/GameSideBounce.test.ts
+++ b/src/GameSideBounce.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Game } from './Game.js';
+import { Projectile } from './Projectile.js';
+
+vi.mock('kontra/kontra.mjs', async () => {
+  const mod = await import('./kontra.mock.js');
+  return { default: { Sprite: mod.MockSprite, GameObject: mod.MockGameObject, init: mod.init } };
+});
+
+describe('Projectile side boundary behavior', () => {
+  it('bounces off the left wall', () => {
+    const canvas = document.createElement('canvas');
+    canvas.width = 800;
+    canvas.height = 600;
+    const ctx = canvas.getContext('2d')!;
+    const game = new Game(canvas, ctx);
+
+    const projectile = new Projectile(-1, 100, -2, 0, 5, 0, 0);
+    game.projectiles.push(projectile);
+    game.currentTurnProjectiles.push(projectile);
+
+    game.update();
+
+    expect(projectile.dx).toBe(2);
+    expect(game.projectiles.length).toBe(1);
+  });
+
+  it('bounces off the right wall', () => {
+    const canvas = document.createElement('canvas');
+    canvas.width = 800;
+    canvas.height = 600;
+    const ctx = canvas.getContext('2d')!;
+    const game = new Game(canvas, ctx);
+
+    const projectile = new Projectile(791, 100, 2, 0, 5, 0, 0);
+    game.projectiles.push(projectile);
+    game.currentTurnProjectiles.push(projectile);
+
+    game.update();
+
+    expect(projectile.dx).toBe(-2);
+    expect(game.projectiles.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- allow projectiles to bounce off the left and right boundaries
- add tests for side-wall bouncing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688159eade188323b9b1b08a8c18e039