### PR TITLE
Flatten Wurm sprite and add aiming barrel

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -39,6 +39,7 @@ export class Game {
   public fire(wurm: Wurm, weapon: string, angle: number, power: number) {
     const { radius, damage, explosionRadius } = weaponProperties[weapon];
     const radians = angle * Math.PI / 180;
+    wurm.barrelAngle = angle;
     const offset = wurm.width / 2 + radius + 0.1;
     const startX = wurm.x + wurm.width / 2 + Math.cos(radians) * offset - radius;
     const startY = wurm.y + wurm.height / 2 - Math.sin(radians) * offset - radius;

--- a/src/ProjectileWurmCollision.test.ts
+++ b/src/ProjectileWurmCollision.test.ts
@@ -24,7 +24,7 @@ vi.mock('kontra/kontra.mjs', () => ({
 
 describe('handleProjectileWurmCollision', () => {
   it('damages wurm and destroys terrain when projectile collides', () => {
-    const wurm = new Wurm(0, 0, 100, 'blue');
+    const wurm = new Wurm(0, 10, 100, 'blue');
     const projectile = new Projectile(0, 0, 0, 0, 5, 20, 10);
     const terrain = { destroy: vi.fn() } as any;
     const result = handleProjectileWurmCollision(projectile, wurm, terrain);

--- a/src/Wurm.test.ts
+++ b/src/Wurm.test.ts
@@ -44,13 +44,13 @@ describe('Wurm', () => {
     const wurm = new Wurm(0, 20, 100, 'red');
     const terrain = { isColliding: vi.fn().mockReturnValue(false) } as any;
     wurm.update(terrain);
-    expect(wurm.y).toBeGreaterThan(0);
+    expect(wurm.y).toBeGreaterThan(10);
   });
 
   it('does not fall when terrain supports it', () => {
     const wurm = new Wurm(0, 20, 100, 'red');
     const terrain = { isColliding: vi.fn().mockReturnValue(true) } as any;
     wurm.update(terrain);
-    expect(wurm.y).toBe(0);
+    expect(wurm.y).toBe(10);
   });
 });

--- a/src/Wurm.ts
+++ b/src/Wurm.ts
@@ -3,26 +3,39 @@ import kontra from 'kontra/kontra.mjs';
 const { Sprite } = kontra;
 
 export class Wurm extends Sprite {
-  
+
   public health: number;
+  public barrelAngle = 0;
 
   constructor(x: number, y: number, health: number, color: string) {
+    const width = 30;
+    const height = 10;
     super({
       x,
-      y: y - 20, // Adjust y to account for sprite height
+      y: y - height, // Adjust y to account for sprite height
       color,
-      width: 20,
-      height: 20,
+      width,
+      height,
     });
     this.health = health;
     this.dy = 0; // ensure dy is defined for gravity calculations
   }
 
   public draw = () => {
+    // body
     this.context.fillStyle = this.color;
+    this.context.fillRect(this.x, this.y, this.width, this.height);
+
+    // barrel showing current angle
+    const centerX = this.x + this.width / 2;
+    const centerY = this.y;
+    const length = this.width / 2;
+    const radians = this.barrelAngle * Math.PI / 180;
+    this.context.strokeStyle = 'black';
     this.context.beginPath();
-    this.context.arc(this.x + this.width / 2, this.y + this.height / 2, this.width / 2, 0, Math.PI * 2);
-    this.context.fill();
+    this.context.moveTo(centerX, centerY);
+    this.context.lineTo(centerX + Math.cos(radians) * length, centerY - Math.sin(radians) * length);
+    this.context.stroke();
   }
 
   public takeDamage = (amount: number) => {
@@ -33,12 +46,26 @@ export class Wurm extends Sprite {
   }
 
   public collidesWith = (projectile: any): boolean => {
-    // Circular collision detection
-    const dx = this.x + this.width / 2 - projectile.x;
-    const dy = this.y + this.height / 2 - projectile.y;
-    const distance = Math.sqrt(dx * dx + dy * dy);
+    const circleX = projectile.x + projectile.radius;
+    const circleY = projectile.y + projectile.radius;
 
-    return distance < this.width / 2 + projectile.radius;
+    const rectX = this.x;
+    const rectY = this.y;
+    const rectW = this.width;
+    const rectH = this.height;
+
+    const distX = Math.abs(circleX - (rectX + rectW / 2));
+    const distY = Math.abs(circleY - (rectY + rectH / 2));
+
+    if (distX > rectW / 2 + projectile.radius) return false;
+    if (distY > rectH / 2 + projectile.radius) return false;
+
+    if (distX <= rectW / 2) return true;
+    if (distY <= rectH / 2) return true;
+
+    const dx = distX - rectW / 2;
+    const dy = distY - rectH / 2;
+    return dx * dx + dy * dy <= projectile.radius * projectile.radius;
   }
 
   public update = (terrain?: any) => {

--- a/src/Wurm.ts
+++ b/src/Wurm.ts
@@ -22,7 +22,6 @@ export class Wurm extends Sprite {
   }
 
   public draw = () => {
-    // body
     this.context.fillStyle = this.color;
     this.context.fillRect(this.x, this.y, this.width, this.height);
 
@@ -31,7 +30,7 @@ export class Wurm extends Sprite {
     const centerY = this.y;
     const length = this.width / 2;
     const radians = this.barrelAngle * Math.PI / 180;
-    this.context.strokeStyle = 'black';
+    this.context.strokeStyle = 'white';
     this.context.beginPath();
     this.context.moveTo(centerX, centerY);
     this.context.lineTo(centerX + Math.cos(radians) * length, centerY - Math.sin(radians) * length);

--- a/src/Wurm.ts
+++ b/src/Wurm.ts
@@ -31,6 +31,7 @@ export class Wurm extends Sprite {
     const length = this.width / 2;
     const radians = this.barrelAngle * Math.PI / 180;
     this.context.strokeStyle = 'white';
+    this.context.lineWidth = 3;
     this.context.beginPath();
     this.context.moveTo(centerX, centerY);
     this.context.lineTo(centerX + Math.cos(radians) * length, centerY - Math.sin(radians) * length);

--- a/src/main.ts
+++ b/src/main.ts
@@ -57,6 +57,7 @@ function startGame() {
   let whoseTurn: 'player' | 'ai' = 'player';
 
   const { playerWurm, aiWurm, terrain, currentTurnProjectiles } = game;
+  playerWurm.barrelAngle = parseFloat((document.getElementById('angle') as HTMLInputElement).value);
 
   // AI Model
   let aiModel: DQNModel | null = null;
@@ -84,6 +85,7 @@ function startGame() {
   // Update angle and power display
   angleInput.addEventListener('input', () => {
     angleValueSpan.textContent = angleInput.value;
+    playerWurm.barrelAngle = parseFloat(angleInput.value);
   });
   powerInput.addEventListener('input', () => {
     powerValueSpan.textContent = powerInput.value;

--- a/src/main.ts
+++ b/src/main.ts
@@ -240,6 +240,7 @@ const aiDemoLoop = GameLoop({
       const radians = aiAngle * Math.PI / 180;
       const shooter = aiDemoTurn === 'wurm1' ? aiDemoWurm1 : aiDemoWurm2;
       const direction = aiDemoTurn === 'wurm1' ? 1 : -1;
+      shooter.barrelAngle = direction === 1 ? aiAngle : 180 - aiAngle;
       const startX = shooter.x + shooter.width / 2 + Math.cos(radians) * radius * direction - radius;
       const startY = shooter.y + shooter.height / 2 - Math.sin(radians) * radius - radius;
       const velX = aiPower * Math.cos(radians) * 0.15 * direction;


### PR DESCRIPTION
## Summary
- render wurms as flat rectangles instead of circles
- show the firing angle with a barrel
- update projectile collision logic for rectangular wurms
- sync UI angle slider with the player's barrel
- adjust unit tests for new geometry

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68815a3c357483238b8e76ea2998b10a