### PR TITLE
Implement grenade fuse and bounce

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -126,10 +126,7 @@ export class Game {
           grenade.dy = -grenade.dy * 0.5;
           grenade.dx *= 0.7;
         }
-        const fuseExpired =
-          typeof (grenade as any).isFuseExpired === 'function'
-            ? (grenade as Grenade).isFuseExpired()
-            : grenade.fuse <= 0;
+        const fuseExpired = grenade.exploded || grenade.fuse <= 0;
         if (fuseExpired) {
           this.explodeGrenade(i, grenade);
           continue;

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -103,7 +103,19 @@ export class Game {
       const projectile = this.projectiles[i];
       const prevX = projectile.x;
       const prevY = projectile.y;
-      projectile.update();
+      if (typeof projectile.update === 'function') {
+        projectile.update();
+      }
+      if (
+        projectile.isGrenade &&
+        !(projectile instanceof Projectile) &&
+        typeof projectile.fuse === 'number'
+      ) {
+        projectile.fuse -= 1;
+        if (projectile.fuse <= 0) {
+          projectile.exploded = true;
+        }
+      }
       if (projectile.x < 0) {
         projectile.x = 0;
         projectile.dx = -projectile.dx;

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -79,28 +79,29 @@ export class Game {
       }
 
       if (projectile.isGrenade) {
-        const hitPlayer = this.playerWurm.collidesWith(projectile);
-        const hitAi = this.aiWurm.collidesWith(projectile);
+        const grenade = projectile as Grenade;
+        const hitPlayer = this.playerWurm.collidesWith(grenade);
+        const hitAi = this.aiWurm.collidesWith(grenade);
         const hitTerrain = this.terrain.isColliding(
-          projectile.x + projectile.radius,
-          projectile.y + projectile.radius
+          grenade.x + grenade.radius,
+          grenade.y + grenade.radius
         );
         if (hitPlayer || hitAi || hitTerrain) {
-          projectile.x = prevX;
-          projectile.y = prevY;
-          projectile.dy = -projectile.dy * 0.5;
-          projectile.dx *= 0.7;
+          grenade.x = prevX;
+          grenade.y = prevY;
+          grenade.dy = -grenade.dy * 0.5;
+          grenade.dx *= 0.7;
         }
-        if (projectile.isFuseExpired()) {
-          this.terrain.destroy(projectile.x + projectile.radius, projectile.y + projectile.radius, projectile.explosionRadius);
+        if (typeof grenade.isFuseExpired === 'function' && grenade.isFuseExpired()) {
+          this.terrain.destroy(grenade.x + grenade.radius, grenade.y + grenade.radius, grenade.explosionRadius);
           if (hitPlayer) {
-            this.playerWurm.takeDamage(projectile.damage);
+            this.playerWurm.takeDamage(grenade.damage);
           }
           if (hitAi) {
-            this.aiWurm.takeDamage(projectile.damage);
+            this.aiWurm.takeDamage(grenade.damage);
           }
           this.projectiles.splice(i, 1);
-          this.removeFromCurrent(projectile);
+          this.removeFromCurrent(grenade);
           continue;
         }
         if (

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -78,7 +78,7 @@ export class Game {
         projectile.dx = -projectile.dx;
       }
 
-      if (projectile instanceof Grenade) {
+      if (projectile.isGrenade) {
         const hitPlayer = this.playerWurm.collidesWith(projectile);
         const hitAi = this.aiWurm.collidesWith(projectile);
         const hitTerrain = this.terrain.isColliding(

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -126,7 +126,11 @@ export class Game {
           grenade.dy = -grenade.dy * 0.5;
           grenade.dx *= 0.7;
         }
-        if (grenade.isFuseExpired()) {
+        const fuseExpired =
+          typeof (grenade as any).isFuseExpired === 'function'
+            ? (grenade as Grenade).isFuseExpired()
+            : grenade.fuse <= 0;
+        if (fuseExpired) {
           this.explodeGrenade(i, grenade);
           continue;
         }

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -67,6 +67,8 @@ export class Game {
     this.aiWurm.update(this.terrain);
     for (let i = this.projectiles.length - 1; i >= 0; i--) {
       const projectile = this.projectiles[i];
+      const prevX = projectile.x;
+      const prevY = projectile.y;
       projectile.update();
       if (projectile.x < 0) {
         projectile.x = 0;
@@ -79,8 +81,13 @@ export class Game {
       if (projectile instanceof Grenade) {
         const hitPlayer = this.playerWurm.collidesWith(projectile);
         const hitAi = this.aiWurm.collidesWith(projectile);
-        const hitTerrain = this.terrain.isColliding(projectile.x + projectile.radius, projectile.y + projectile.radius);
+        const hitTerrain = this.terrain.isColliding(
+          projectile.x + projectile.radius,
+          projectile.y + projectile.radius
+        );
         if (hitPlayer || hitAi || hitTerrain) {
+          projectile.x = prevX;
+          projectile.y = prevY;
           projectile.dy = -projectile.dy * 0.5;
           projectile.dx *= 0.7;
         }

--- a/src/Grenade.test.ts
+++ b/src/Grenade.test.ts
@@ -61,4 +61,25 @@ describe('Grenade behavior', () => {
     expect(game.projectiles.length).toBe(0);
     expect(destroySpy).toHaveBeenCalled();
   });
+
+  it('handles missing isFuseExpired method', () => {
+    const canvas = document.createElement('canvas');
+    canvas.width = 800;
+    canvas.height = 600;
+    const ctx = canvas.getContext('2d')!;
+    const game = new Game(canvas, ctx);
+
+    const grenade = new Grenade(100, 100, 0, 0, 5, 10, 20, 1);
+    // @ts-expect-error deliberately remove method for test
+    (grenade as any).isFuseExpired = undefined;
+    game.projectiles.push(grenade);
+    game.currentTurnProjectiles.push(grenade);
+    vi.spyOn(game.terrain, 'isColliding').mockReturnValue(false);
+    const destroySpy = vi.spyOn(game.terrain, 'destroy');
+
+    game.update();
+
+    expect(game.projectiles.length).toBe(0);
+    expect(destroySpy).toHaveBeenCalled();
+  });
 });

--- a/src/Grenade.test.ts
+++ b/src/Grenade.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Grenade } from './Grenade.js';
+import { Game } from './Game.js';
+
+vi.mock('kontra/kontra.mjs', async () => {
+  const mod = await import('./kontra.mock.js');
+  return { default: { Sprite: mod.MockSprite, GameObject: mod.MockGameObject, init: mod.init } };
+});
+
+describe('Grenade behavior', () => {
+  it('does not explode on first impact', () => {
+    const canvas = document.createElement('canvas');
+    canvas.width = 800;
+    canvas.height = 600;
+    const ctx = canvas.getContext('2d')!;
+    const game = new Game(canvas, ctx);
+
+    const grenade = new Grenade(100, 100, 0, 0, 5, 10, 20, 2);
+    game.projectiles.push(grenade);
+    game.currentTurnProjectiles.push(grenade);
+    vi.spyOn(game.terrain, 'isColliding').mockReturnValue(true);
+
+    game.update();
+
+    expect(game.projectiles.length).toBe(1);
+    expect(game.playerWurm.health).toBe(100);
+  });
+
+  it('explodes after fuse expires', () => {
+    const canvas = document.createElement('canvas');
+    canvas.width = 800;
+    canvas.height = 600;
+    const ctx = canvas.getContext('2d')!;
+    const game = new Game(canvas, ctx);
+
+    const grenade = new Grenade(100, 100, 0, 0, 5, 10, 20, 1);
+    game.projectiles.push(grenade);
+    game.currentTurnProjectiles.push(grenade);
+    vi.spyOn(game.terrain, 'isColliding').mockReturnValue(false);
+
+    game.update();
+
+    expect(game.projectiles.length).toBe(0);
+  });
+});

--- a/src/Grenade.test.ts
+++ b/src/Grenade.test.ts
@@ -91,9 +91,19 @@ describe('Grenade behavior', () => {
     const ctx = canvas.getContext('2d')!;
     const game = new Game(canvas, ctx);
 
-    const projectile = new Projectile(100, 100, 0, 0, 5, 10, 20);
-    projectile.isGrenade = true;
-    (projectile as any).fuse = 1;
+    const projectile: any = {
+      x: 100,
+      y: 100,
+      dx: 0,
+      dy: 0,
+      radius: 5,
+      damage: 10,
+      explosionRadius: 20,
+      isGrenade: true,
+      fuse: 1,
+      exploded: false,
+      update: vi.fn()
+    };
     game.projectiles.push(projectile);
     game.currentTurnProjectiles.push(projectile);
     vi.spyOn(game.terrain, 'isColliding').mockReturnValue(false);

--- a/src/Grenade.test.ts
+++ b/src/Grenade.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { Grenade } from './Grenade.js';
+import { Projectile } from './Projectile.js';
 import { Game } from './Game.js';
 
 vi.mock('kontra/kontra.mjs', async () => {
@@ -74,6 +75,27 @@ describe('Grenade behavior', () => {
     (grenade as any).isFuseExpired = undefined;
     game.projectiles.push(grenade);
     game.currentTurnProjectiles.push(grenade);
+    vi.spyOn(game.terrain, 'isColliding').mockReturnValue(false);
+    const destroySpy = vi.spyOn(game.terrain, 'destroy');
+
+    game.update();
+
+    expect(game.projectiles.length).toBe(0);
+    expect(destroySpy).toHaveBeenCalled();
+  });
+
+  it('ticks fuse on non-Grenade instances', () => {
+    const canvas = document.createElement('canvas');
+    canvas.width = 800;
+    canvas.height = 600;
+    const ctx = canvas.getContext('2d')!;
+    const game = new Game(canvas, ctx);
+
+    const projectile = new Projectile(100, 100, 0, 0, 5, 10, 20);
+    projectile.isGrenade = true;
+    (projectile as any).fuse = 1;
+    game.projectiles.push(projectile);
+    game.currentTurnProjectiles.push(projectile);
     vi.spyOn(game.terrain, 'isColliding').mockReturnValue(false);
     const destroySpy = vi.spyOn(game.terrain, 'destroy');
 

--- a/src/Grenade.test.ts
+++ b/src/Grenade.test.ts
@@ -54,9 +54,11 @@ describe('Grenade behavior', () => {
     game.projectiles.push(grenade);
     game.currentTurnProjectiles.push(grenade);
     vi.spyOn(game.terrain, 'isColliding').mockReturnValue(false);
+    const destroySpy = vi.spyOn(game.terrain, 'destroy');
 
     game.update();
 
     expect(game.projectiles.length).toBe(0);
+    expect(destroySpy).toHaveBeenCalled();
   });
 });

--- a/src/Grenade.test.ts
+++ b/src/Grenade.test.ts
@@ -26,6 +26,23 @@ describe('Grenade behavior', () => {
     expect(game.playerWurm.health).toBe(100);
   });
 
+  it('bounces on terrain impact', () => {
+    const canvas = document.createElement('canvas');
+    canvas.width = 800;
+    canvas.height = 600;
+    const ctx = canvas.getContext('2d')!;
+    const game = new Game(canvas, ctx);
+
+    const grenade = new Grenade(100, 100, 0, 2, 5, 10, 20, 2);
+    game.projectiles.push(grenade);
+    game.currentTurnProjectiles.push(grenade);
+    vi.spyOn(game.terrain, 'isColliding').mockReturnValue(true);
+
+    game.update();
+
+    expect(grenade.dy).toBe(-1);
+  });
+
   it('explodes after fuse expires', () => {
     const canvas = document.createElement('canvas');
     canvas.width = 800;

--- a/src/Grenade.ts
+++ b/src/Grenade.ts
@@ -1,0 +1,19 @@
+import { Projectile } from './Projectile.js';
+
+export class Grenade extends Projectile {
+  public fuse: number;
+
+  constructor(x: number, y: number, dx: number, dy: number, radius: number, damage: number, explosionRadius: number, fuse: number = 180) {
+    super(x, y, dx, dy, radius, damage, explosionRadius);
+    this.fuse = fuse;
+  }
+
+  public update() {
+    super.update();
+    this.fuse--;
+  }
+
+  public isFuseExpired(): boolean {
+    return this.fuse <= 0;
+  }
+}

--- a/src/Grenade.ts
+++ b/src/Grenade.ts
@@ -2,20 +2,11 @@ import { Projectile } from './Projectile.js';
 
 export class Grenade extends Projectile {
   public fuse: number;
-  public exploded = false;
 
   constructor(x: number, y: number, dx: number, dy: number, radius: number, damage: number, explosionRadius: number, fuse: number = 180) {
     super(x, y, dx, dy, radius, damage, explosionRadius);
     this.isGrenade = true;
     this.fuse = fuse;
-  }
-
-  public update() {
-    super.update();
-    this.fuse--;
-    if (this.fuse <= 0) {
-      this.exploded = true;
-    }
   }
 
   public isFuseExpired(): boolean {

--- a/src/Grenade.ts
+++ b/src/Grenade.ts
@@ -2,6 +2,7 @@ import { Projectile } from './Projectile.js';
 
 export class Grenade extends Projectile {
   public fuse: number;
+  public exploded = false;
 
   constructor(x: number, y: number, dx: number, dy: number, radius: number, damage: number, explosionRadius: number, fuse: number = 180) {
     super(x, y, dx, dy, radius, damage, explosionRadius);
@@ -12,6 +13,9 @@ export class Grenade extends Projectile {
   public update() {
     super.update();
     this.fuse--;
+    if (this.fuse <= 0) {
+      this.exploded = true;
+    }
   }
 
   public isFuseExpired(): boolean {

--- a/src/Grenade.ts
+++ b/src/Grenade.ts
@@ -5,6 +5,7 @@ export class Grenade extends Projectile {
 
   constructor(x: number, y: number, dx: number, dy: number, radius: number, damage: number, explosionRadius: number, fuse: number = 180) {
     super(x, y, dx, dy, radius, damage, explosionRadius);
+    this.isGrenade = true;
     this.fuse = fuse;
   }
 

--- a/src/Projectile.ts
+++ b/src/Projectile.ts
@@ -8,6 +8,8 @@ export class Projectile extends Sprite {
   public damage: number;
   public explosionRadius: number;
   public isGrenade = false;
+  public fuse = 0;
+  public exploded = false;
 
   constructor(x: number, y: number, dx: number, dy: number, radius: number, damage: number, explosionRadius: number) {
     super({
@@ -29,5 +31,11 @@ export class Projectile extends Sprite {
 
   public update() {
     this.advance();
+    if (this.isGrenade && typeof this.fuse === 'number') {
+      this.fuse--;
+      if (this.fuse <= 0) {
+        this.exploded = true;
+      }
+    }
   }
 }

--- a/src/Projectile.ts
+++ b/src/Projectile.ts
@@ -3,10 +3,11 @@ import kontra from 'kontra/kontra.mjs';
 const { Sprite } = kontra;
 
 export class Projectile extends Sprite {
-  
+
   public radius: number;
   public damage: number;
   public explosionRadius: number;
+  public isGrenade = false;
 
   constructor(x: number, y: number, dx: number, dy: number, radius: number, damage: number, explosionRadius: number) {
     super({


### PR DESCRIPTION
## Summary
- implement a dedicated `Grenade` projectile with fuse countdown
- create grenades when firing the `grenade` weapon
- make grenades bounce on impact and explode only after the fuse expires
- test grenade fuse and bounce behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688179bcad848323837d7c4d238a1199