### PR TITLE
Add explosion animation

### DIFF
--- a/src/Explosion.ts
+++ b/src/Explosion.ts
@@ -1,0 +1,34 @@
+export class Explosion {
+  private x: number;
+  private y: number;
+  private maxRadius: number;
+  private duration: number;
+  private frame: number = 0;
+
+  constructor(x: number, y: number, maxRadius: number, duration = 30) {
+    this.x = x;
+    this.y = y;
+    this.maxRadius = maxRadius;
+    this.duration = duration;
+  }
+
+  public update() {
+    this.frame++;
+  }
+
+  public draw(context: CanvasRenderingContext2D) {
+    const progress = this.frame / this.duration;
+    const radius = this.maxRadius * progress;
+    context.save();
+    context.globalAlpha = 1 - progress;
+    context.fillStyle = 'orange';
+    context.beginPath();
+    context.arc(this.x, this.y, radius, 0, Math.PI * 2);
+    context.fill();
+    context.restore();
+  }
+
+  public isDone(): boolean {
+    return this.frame >= this.duration;
+  }
+}

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -5,6 +5,7 @@ import { Projectile } from './Projectile.js';
 import { Wurm } from './Wurm.js';
 import { weaponProperties } from './WeaponProperties.js';
 import { handleProjectileWurmCollision } from './collision.js';
+import { Explosion } from './Explosion.js';
 
 export class Game {
   public terrain: Terrain;
@@ -12,6 +13,7 @@ export class Game {
   public aiWurm: Wurm;
   public projectiles: Projectile[] = [];
   public currentTurnProjectiles: Projectile[] = [];
+  public explosions: Explosion[] = [];
   private canvas: HTMLCanvasElement;
   private context: CanvasRenderingContext2D;
 
@@ -34,6 +36,7 @@ export class Game {
     this.aiWurm.health = 100;
     this.projectiles = [];
     this.currentTurnProjectiles = [];
+    this.explosions = [];
   }
 
   public fire(wurm: Wurm, weapon: string, angle: number, power: number) {
@@ -74,18 +77,39 @@ export class Game {
       }
       if (handleProjectileWurmCollision(projectile, this.playerWurm, this.terrain)) {
         console.log('Player hit!');
+        this.explosions.push(
+          new Explosion(
+            projectile.x + projectile.radius,
+            projectile.y + projectile.radius,
+            projectile.explosionRadius
+          )
+        );
         this.projectiles.splice(i, 1);
         this.removeFromCurrent(projectile);
         continue;
       }
       if (handleProjectileWurmCollision(projectile, this.aiWurm, this.terrain)) {
         console.log('AI Wurm hit!');
+        this.explosions.push(
+          new Explosion(
+            projectile.x + projectile.radius,
+            projectile.y + projectile.radius,
+            projectile.explosionRadius
+          )
+        );
         this.projectiles.splice(i, 1);
         this.removeFromCurrent(projectile);
         continue;
       }
       if (this.terrain.isColliding(projectile.x + projectile.radius, projectile.y + projectile.radius)) {
         this.terrain.destroy(projectile.x + projectile.radius, projectile.y + projectile.radius, projectile.explosionRadius);
+        this.explosions.push(
+          new Explosion(
+            projectile.x + projectile.radius,
+            projectile.y + projectile.radius,
+            projectile.explosionRadius
+          )
+        );
         this.projectiles.splice(i, 1);
         this.removeFromCurrent(projectile);
         if (this.playerWurm.collidesWith(projectile)) {
@@ -101,6 +125,14 @@ export class Game {
       ) {
         this.projectiles.splice(i, 1);
         this.removeFromCurrent(projectile);
+      }
+    }
+
+    for (let i = this.explosions.length - 1; i >= 0; i--) {
+      const explosion = this.explosions[i];
+      explosion.update();
+      if (explosion.isDone()) {
+        this.explosions.splice(i, 1);
       }
     }
   }
@@ -119,6 +151,9 @@ export class Game {
     this.aiWurm.draw();
     for (const projectile of this.projectiles) {
       projectile.render();
+    }
+    for (const explosion of this.explosions) {
+      explosion.draw(this.context);
     }
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import { getObservation } from './ai/ObservationSpace.js';
 import { WEAPON_CHOICES } from './ai/ActionSpace.js';
 import { weaponProperties } from './WeaponProperties.js';
 import { SoundManager } from './SoundManager.js';
+import { Explosion } from './Explosion.js';
 
 // Sound Manager
 const soundManager = new SoundManager();
@@ -209,6 +210,7 @@ let aiDemoTerrain: Terrain;
 let aiDemoWurm1: Wurm;
 let aiDemoWurm2: Wurm;
 let aiDemoProjectiles: Projectile[] = [];
+let aiDemoExplosions: Explosion[] = [];
 let aiDemoTurn: 'wurm1' | 'wurm2' = 'wurm1';
 
 function initAiDemo() {
@@ -221,6 +223,7 @@ function initAiDemo() {
     'yellow'
   );
   aiDemoProjectiles = [];
+  aiDemoExplosions = [];
   aiDemoTurn = 'wurm1';
 }
 
@@ -268,10 +271,23 @@ const aiDemoLoop = GameLoop({
       if (aiDemoTerrain.isColliding(projectile.x + projectile.radius, projectile.y + projectile.radius)) {
         console.log(`AI Demo Projectile removed: Terrain collision at x: ${projectile.x}, y: ${projectile.y}, radius: ${projectile.radius}`);
         aiDemoTerrain.destroy(projectile.x + projectile.radius, projectile.y + projectile.radius, projectile.explosionRadius);
+        aiDemoExplosions.push(new Explosion(
+          projectile.x + projectile.radius,
+          projectile.y + projectile.radius,
+          projectile.explosionRadius
+        ));
         aiDemoProjectiles.splice(i, 1);
         soundManager.playSound('explosion');
       } else if (projectile.x + (projectile.radius * 2) < 0 || projectile.x > aiDemoCanvas.width || projectile.y + (projectile.radius * 2) < 0 || projectile.y > aiDemoCanvas.height) {
         aiDemoProjectiles.splice(i, 1);
+      }
+    }
+
+    for (let i = aiDemoExplosions.length - 1; i >= 0; i--) {
+      const explosion = aiDemoExplosions[i];
+      explosion.update();
+      if (explosion.isDone()) {
+        aiDemoExplosions.splice(i, 1);
       }
     }
   },
@@ -282,6 +298,9 @@ const aiDemoLoop = GameLoop({
     aiDemoWurm2.draw();
     for (const projectile of aiDemoProjectiles) {
       projectile.render();
+    }
+    for (const explosion of aiDemoExplosions) {
+      explosion.draw(aiDemoContext);
     }
   }
 });


### PR DESCRIPTION
## Summary
- create `Explosion` helper class for animations
- animate explosions in `Game` and AI demo

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688180e597608323a0a181e74cb1fb7c