### PR TITLE
Add explosion damage

### DIFF
--- a/src/Game.test.ts
+++ b/src/Game.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { Game } from './Game.js';
+import { Projectile } from './Projectile.js';
 
 vi.mock('kontra/kontra.mjs', async () => {
   const mod = await import('./kontra.mock.js');
@@ -16,5 +17,28 @@ describe('Game projectile spawning', () => {
     game.fire(game.playerWurm, 'bazooka', 45, 50);
     game.update();
     expect(game.playerWurm.health).toBe(100);
+  });
+
+  it('damages wurm when explosion occurs nearby', () => {
+    const canvas = document.createElement('canvas');
+    canvas.width = 800;
+    canvas.height = 600;
+    const ctx = canvas.getContext('2d')!;
+    const game = new Game(canvas, ctx);
+    const projectile = new Projectile(
+      game.playerWurm.x + game.playerWurm.width + 1,
+      game.playerWurm.y,
+      0,
+      0,
+      5,
+      20,
+      30,
+      0
+    );
+    game.projectiles.push(projectile);
+    game.currentTurnProjectiles.push(projectile);
+    vi.spyOn(game.terrain, 'isColliding').mockReturnValue(true);
+    game.update();
+    expect(game.playerWurm.health).toBe(80);
   });
 });

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -16,6 +16,23 @@ export class Game {
   public explosions: Explosion[] = [];
   private canvas: HTMLCanvasElement;
   private context: CanvasRenderingContext2D;
+  private applyExplosionDamage(
+    x: number,
+    y: number,
+    radius: number,
+    damage: number
+  ) {
+    const damageWurm = (wurm: Wurm) => {
+      const centerX = wurm.x + wurm.width / 2;
+      const centerY = wurm.y + wurm.height / 2;
+      const distance = Math.hypot(centerX - x, centerY - y);
+      if (distance <= radius) {
+        wurm.takeDamage(damage);
+      }
+    };
+    damageWurm(this.playerWurm);
+    damageWurm(this.aiWurm);
+  }
 
   constructor(canvas: HTMLCanvasElement, context: CanvasRenderingContext2D) {
     this.canvas = canvas;
@@ -97,6 +114,12 @@ export class Game {
             projectile.explosionRadius
           )
         );
+        this.applyExplosionDamage(
+          projectile.x + projectile.radius,
+          projectile.y + projectile.radius,
+          projectile.explosionRadius,
+          projectile.damage
+        );
         this.projectiles.splice(i, 1);
         this.removeFromCurrent(projectile);
         continue;
@@ -110,6 +133,12 @@ export class Game {
             projectile.explosionRadius
           )
         );
+        this.applyExplosionDamage(
+          projectile.x + projectile.radius,
+          projectile.y + projectile.radius,
+          projectile.explosionRadius,
+          projectile.damage
+        );
         this.projectiles.splice(i, 1);
         this.removeFromCurrent(projectile);
         continue;
@@ -119,18 +148,18 @@ export class Game {
         if (projectile.fuse > 0) {
           projectile.x = prevX;
           projectile.y = prevY;
-          projectile.dy = -projectile.dy * 0.5;
+          projectile.dy = -projectile.dy;
           projectile.dx *= 0.7;
         } else {
           this.terrain.destroy(projectile.x + projectile.radius, projectile.y + projectile.radius, projectile.explosionRadius);
+          this.applyExplosionDamage(
+            projectile.x + projectile.radius,
+            projectile.y + projectile.radius,
+            projectile.explosionRadius,
+            projectile.damage
+          );
           this.projectiles.splice(i, 1);
           this.removeFromCurrent(projectile);
-          if (this.playerWurm.collidesWith(projectile)) {
-            this.playerWurm.takeDamage(projectile.damage);
-          }
-          if (this.aiWurm.collidesWith(projectile)) {
-            this.aiWurm.takeDamage(projectile.damage);
-          }
           continue;
         }
       } else if (
@@ -152,14 +181,14 @@ export class Game {
             projectile.explosionRadius
           )
         );
+        this.applyExplosionDamage(
+          projectile.x + projectile.radius,
+          projectile.y + projectile.radius,
+          projectile.explosionRadius,
+          projectile.damage
+        );
         this.projectiles.splice(i, 1);
         this.removeFromCurrent(projectile);
-        if (this.playerWurm.collidesWith(projectile)) {
-          this.playerWurm.takeDamage(projectile.damage);
-        }
-        if (this.aiWurm.collidesWith(projectile)) {
-          this.aiWurm.takeDamage(projectile.damage);
-        }
         continue;
       }
 

--- a/src/ProjectileWurmCollision.test.ts
+++ b/src/ProjectileWurmCollision.test.ts
@@ -23,13 +23,13 @@ vi.mock('kontra/kontra.mjs', () => ({
 }));
 
 describe('handleProjectileWurmCollision', () => {
-  it('damages wurm and destroys terrain when projectile collides', () => {
+  it('returns true and destroys terrain when projectile collides', () => {
     const wurm = new Wurm(0, 10, 100, 'blue');
     const projectile = new Projectile(0, 0, 0, 0, 5, 20, 10, 0);
     const terrain = { destroy: vi.fn() } as any;
     const result = handleProjectileWurmCollision(projectile, wurm, terrain);
     expect(result).toBe(true);
-    expect(wurm.health).toBe(80);
+    expect(wurm.health).toBe(100);
     expect(terrain.destroy).toHaveBeenCalledWith(0, 0, 10);
   });
 

--- a/src/collision.ts
+++ b/src/collision.ts
@@ -8,7 +8,6 @@ export function handleProjectileWurmCollision(
   terrain: Terrain
 ): boolean {
   if (wurm.collidesWith(projectile)) {
-    wurm.takeDamage(projectile.damage);
     terrain.destroy(projectile.x, projectile.y, projectile.explosionRadius);
     return true;
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -213,6 +213,19 @@ let aiDemoProjectiles: Projectile[] = [];
 let aiDemoExplosions: Explosion[] = [];
 let aiDemoTurn: 'wurm1' | 'wurm2' = 'wurm1';
 
+function applyDemoExplosionDamage(x: number, y: number, radius: number, damage: number) {
+  const damageWurm = (wurm: Wurm) => {
+    const centerX = wurm.x + wurm.width / 2;
+    const centerY = wurm.y + wurm.height / 2;
+    const distance = Math.hypot(centerX - x, centerY - y);
+    if (distance <= radius) {
+      wurm.takeDamage(damage);
+    }
+  };
+  damageWurm(aiDemoWurm1);
+  damageWurm(aiDemoWurm2);
+}
+
 function initAiDemo() {
   aiDemoTerrain = new Terrain(aiDemoCanvas.width, aiDemoCanvas.height, aiDemoContext);
   aiDemoWurm1 = new Wurm(50, aiDemoTerrain.getGroundHeight(50), 100, 'red');
@@ -277,6 +290,12 @@ const aiDemoLoop = GameLoop({
           projectile.y + projectile.radius,
           projectile.explosionRadius
         ));
+        applyDemoExplosionDamage(
+          projectile.x + projectile.radius,
+          projectile.y + projectile.radius,
+          projectile.explosionRadius,
+          projectile.damage
+        );
         aiDemoProjectiles.splice(i, 1);
         soundManager.playSound('explosion');
       } else if (projectile.x + (projectile.radius * 2) < 0 || projectile.x > aiDemoCanvas.width || projectile.y + (projectile.radius * 2) < 0 || projectile.y > aiDemoCanvas.height) {


### PR DESCRIPTION
## Summary
- damage worms when explosions occur
- test explosion damage with new unit test
- adjust grenade bounce physics
- update collision logic
- improve AI demo to also deal explosion damage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881d2fdc6208323b3eba1c34ecd10fd