### PR TITLE
Add seeded terrain generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ npm run dev
 
 This will start a development server and open the game in your browser.
 
+You can provide a seed for map generation by appending `?seed=<number>` to the
+URL when launching the game. Using the same seed recreates the same terrain.
+
 ## Tech Stack
 
 *   **TypeScript**

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -48,18 +48,31 @@ export class Game {
     damageWurm(this.aiWurm);
   }
 
-  constructor(canvas: HTMLCanvasElement, context: CanvasRenderingContext2D) {
+  private mapSeed?: number;
+
+  constructor(
+    canvas: HTMLCanvasElement,
+    context: CanvasRenderingContext2D,
+    seed?: number
+  ) {
     this.canvas = canvas;
     this.context = context;
     init(canvas);
-    this.terrain = new Terrain(canvas.width, canvas.height, context);
+    this.mapSeed = seed;
+    this.terrain = new Terrain(canvas.width, canvas.height, context, seed);
     const [playerX, aiX] = this.getSpawnPositions();
     this.playerWurm = new Wurm(playerX, this.terrain.getGroundHeight(playerX), 100, 'blue');
     this.aiWurm = new Wurm(aiX, this.terrain.getGroundHeight(aiX), 100, 'red');
   }
 
-  public reset() {
-    this.terrain = new Terrain(this.canvas.width, this.canvas.height, this.context);
+  public reset(seed?: number) {
+    this.mapSeed = seed ?? this.mapSeed;
+    this.terrain = new Terrain(
+      this.canvas.width,
+      this.canvas.height,
+      this.context,
+      this.mapSeed
+    );
     const [playerX, aiX] = this.getSpawnPositions();
     this.playerWurm.x = playerX;
     this.playerWurm.y = this.terrain.getGroundHeight(playerX) - this.playerWurm.height;

--- a/src/Terrain.ts
+++ b/src/Terrain.ts
@@ -79,21 +79,21 @@ export class Terrain extends GameObject {
     return baseHeight + total;
   };
 
-  private generateNoiseParameters() {
+  private generateNoiseParameters = () => {
     const octaves = 4;
     for (let i = 0; i < octaves; i++) {
       this.phases[i] = this.random() * Math.PI * 2;
       this.amplitudes[i] =
         (this.height / 4) * (0.5 ** i) * (0.5 + this.random() * 0.5);
     }
-  }
+  };
 
-  private mulberry32(a: number) {
+  private mulberry32 = (a: number) => {
     return () => {
       let t = (a += 0x6d2b79f5);
       t = Math.imul(t ^ (t >>> 15), t | 1);
       t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
       return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
     };
-  }
+  };
 }

--- a/src/Terrain.ts
+++ b/src/Terrain.ts
@@ -5,14 +5,28 @@ const { GameObject } = kontra;
 export class Terrain extends GameObject {
   private terrainCanvas: HTMLCanvasElement;
   private terrainContext: CanvasRenderingContext2D;
+  private random: () => number;
+  private phases: number[] = [];
+  private amplitudes: number[] = [];
+  private readonly seed: number;
 
-  constructor(width: number, height: number, context: CanvasRenderingContext2D) {
+  constructor(
+    width: number,
+    height: number,
+    context: CanvasRenderingContext2D,
+    seed?: number
+  ) {
     super({ width, height, context }); // 'context' here is the main canvas context
+
+    this.seed = seed ?? Math.floor(Math.random() * 1e9);
+    this.random = this.mulberry32(this.seed);
 
     this.terrainCanvas = document.createElement('canvas');
     this.terrainCanvas.width = width;
     this.terrainCanvas.height = height;
     this.terrainContext = this.terrainCanvas.getContext('2d')!;
+
+    this.generateNoiseParameters();
 
     // Draw initial terrain onto the offscreen canvas
     this.drawInitialTerrain();
@@ -56,19 +70,30 @@ export class Terrain extends GameObject {
   };
 
   public getGroundHeight = (x: number): number => {
-    const noiseScale = 0.01;
-    const perlin = (val: number) => {
-      let n = 0;
-      let a = 1;
-      let f = 0.05;
-      for (let o = 0; o < 4; o++) {
-        n += Math.sin(val * f) * a;
-        a *= 0.5;
-        f *= 2;
-      }
-      return n;
-    };
-    const noiseVal = perlin(x * noiseScale);
-    return (noiseVal * (this.height / 4)) + (this.height / 2);
+    const baseHeight = this.height / 2;
+    let total = 0;
+    for (let i = 0; i < this.phases.length; i++) {
+      const freq = 0.005 * Math.pow(2, i);
+      total += Math.sin(x * freq + this.phases[i]) * this.amplitudes[i];
+    }
+    return baseHeight + total;
   };
+
+  private generateNoiseParameters() {
+    const octaves = 4;
+    for (let i = 0; i < octaves; i++) {
+      this.phases[i] = this.random() * Math.PI * 2;
+      this.amplitudes[i] =
+        (this.height / 4) * (0.5 ** i) * (0.5 + this.random() * 0.5);
+    }
+  }
+
+  private mulberry32(a: number) {
+    return () => {
+      let t = (a += 0x6d2b79f5);
+      t = Math.imul(t ^ (t >>> 15), t | 1);
+      t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+      return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+  }
 }

--- a/src/TerrainSeed.test.ts
+++ b/src/TerrainSeed.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Terrain } from './Terrain.js';
+
+vi.mock('kontra/kontra.mjs', async () => {
+  const mod = await import('./kontra.mock.js');
+  return { default: { GameObject: mod.MockGameObject, Sprite: mod.MockSprite, init: mod.init } };
+});
+
+describe('Terrain seed behavior', () => {
+  it('produces the same terrain with the same seed', () => {
+    const canvas = document.createElement('canvas');
+    const ctx = canvas.getContext('2d')!;
+    const t1 = new Terrain(100, 100, ctx, 42);
+    const t2 = new Terrain(100, 100, ctx, 42);
+    expect(t1.getGroundHeight(50)).toBe(t2.getGroundHeight(50));
+  });
+
+  it('produces different terrain with different seeds', () => {
+    const canvas = document.createElement('canvas');
+    const ctx = canvas.getContext('2d')!;
+    const t1 = new Terrain(100, 100, ctx, 1);
+    const t2 = new Terrain(100, 100, ctx, 2);
+    expect(t1.getGroundHeight(50)).not.toBe(t2.getGroundHeight(50));
+  });
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,14 +32,14 @@ const playAgainButton = document.getElementById('play-again-button') as HTMLButt
 // Main Game Initialization and Loop
 let mainGameLoop: any;
 
-function startGame() {
+function startGame(seed?: number) {
   const canvas = document.getElementById('game') as HTMLCanvasElement;
   const context = canvas.getContext('2d') as CanvasRenderingContext2D;
 
   canvas.width = 800;
   canvas.height = 600;
 
-  const game = new Game(canvas, context);
+  const game = new Game(canvas, context, seed);
 
   window.addEventListener('resize', () => {
     canvas.width = 800;
@@ -334,7 +334,9 @@ startGameButton.addEventListener('click', () => {
   gameScreen.style.display = 'block';
   aiDemoLoop.stop(); // Stop AI demo when game starts
   aiDemoContext.clearRect(0, 0, aiDemoCanvas.width, aiDemoCanvas.height);
-  startGame(); // Start main game loop
+  const param = new URLSearchParams(window.location.search).get('seed');
+  const seed = param ? parseInt(param, 10) : undefined;
+  startGame(seed); // Start main game loop
 });
 
 // Play Again Button


### PR DESCRIPTION
## Summary
- allow Terrain to generate procedural terrain using a seed
- update Game and main to accept optional map seed
- document new seed option in the README
- test deterministic terrain generation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881dbcf272883239f01b6dfa610e8c0