### PR TITLE
Reverse angle slider orientation

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
         </select>
 
         <label for="angle">Angle:</label>
-        <input type="range" id="angle" min="0" max="180" value="45">
+        <input type="range" id="angle" min="0" max="180" value="135">
         <span id="angle-value">45</span>
 
         <label for="power">Power:</label>

--- a/src/main.ts
+++ b/src/main.ts
@@ -58,7 +58,8 @@ function startGame() {
   let whoseTurn: 'player' | 'ai' = 'player';
 
   const { playerWurm, aiWurm, terrain, currentTurnProjectiles } = game;
-  playerWurm.barrelAngle = parseFloat((document.getElementById('angle') as HTMLInputElement).value);
+  const initialAngleInput = document.getElementById('angle') as HTMLInputElement;
+  playerWurm.barrelAngle = 180 - parseFloat(initialAngleInput.value);
 
   // AI Model
   let aiModel: DQNModel | null = null;
@@ -83,10 +84,13 @@ function startGame() {
   const powerValueSpan = document.getElementById('power-value') as HTMLSpanElement;
   const fireButton = document.getElementById('fire') as HTMLButtonElement;
 
+  angleValueSpan.textContent = (180 - parseFloat(angleInput.value)).toString();
+
   // Update angle and power display
   angleInput.addEventListener('input', () => {
-    angleValueSpan.textContent = angleInput.value;
-    playerWurm.barrelAngle = parseFloat(angleInput.value);
+    const angle = 180 - parseFloat(angleInput.value);
+    angleValueSpan.textContent = angle.toString();
+    playerWurm.barrelAngle = angle;
   });
   powerInput.addEventListener('input', () => {
     powerValueSpan.textContent = powerInput.value;
@@ -95,7 +99,7 @@ function startGame() {
   fireButton.addEventListener('click', () => {
     if (currentGameState === GameState.PLANNING) {
       soundManager.playSound('click');
-      const angle = parseFloat(angleInput.value);
+      const angle = 180 - parseFloat(angleInput.value);
       const power = parseFloat(powerInput.value);
       const weapon = weaponSelect.value;
 


### PR DESCRIPTION
## Summary
- reverse barrel angle input so that left side represents 180° and right side represents 0°
- adjust default angle value in the HTML

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881dcdd329c83238e7c3e5dabbb8824