### PR TITLE
Fix sound playback initialization

### DIFF
--- a/src/SoundManager.ts
+++ b/src/SoundManager.ts
@@ -1,18 +1,43 @@
 export class SoundManager {
   private audioContext: AudioContext;
   private sounds: { [key: string]: AudioBuffer } = {};
+  private unlocked = false;
 
   constructor() {
     this.audioContext = new (window.AudioContext || (window as any).webkitAudioContext)();
+    this.addUnlockListeners();
+  }
+
+  private addUnlockListeners() {
+    const unlock = () => {
+      this.audioContext.resume();
+      this.unlocked = true;
+      window.removeEventListener('click', unlock);
+      window.removeEventListener('keydown', unlock);
+    };
+    window.addEventListener('click', unlock);
+    window.addEventListener('keydown', unlock);
+  }
+
+  public unlock() {
+    if (!this.unlocked) {
+      this.audioContext.resume();
+      this.unlocked = true;
+    }
   }
 
   public async loadSound(name: string, url: string) {
-    const response = await fetch(url);
-    const arrayBuffer = await response.arrayBuffer();
-    this.sounds[name] = await this.audioContext.decodeAudioData(arrayBuffer);
+    try {
+      const response = await fetch(url);
+      const arrayBuffer = await response.arrayBuffer();
+      this.sounds[name] = await this.audioContext.decodeAudioData(arrayBuffer);
+    } catch (error) {
+      console.warn(`Failed to load sound ${name} from ${url}`, error);
+    }
   }
 
   public playSound(name: string, volume: number = 1) {
+    if (!this.unlocked) return;
     const sound = this.sounds[name];
     if (sound) {
       const source = this.audioContext.createBufferSource();

--- a/src/main.ts
+++ b/src/main.ts
@@ -330,6 +330,8 @@ const aiDemoLoop = GameLoop({
 
 // Start Game Button
 startGameButton.addEventListener('click', () => {
+  soundManager.unlock();
+  soundManager.playSound('click');
   startScreen.style.display = 'none';
   gameScreen.style.display = 'block';
   aiDemoLoop.stop(); // Stop AI demo when game starts
@@ -341,6 +343,8 @@ startGameButton.addEventListener('click', () => {
 playAgainButton.addEventListener('click', () => {
   gameOverScreen.style.display = 'none';
   startScreen.style.display = 'flex';
+  soundManager.unlock();
+  soundManager.playSound('click');
   initAiDemo();
   aiDemoLoop.start(); // Restart AI demo
 });


### PR DESCRIPTION
## Summary
- add unlock logic to SoundManager to wait for user interaction
- guard playSound until audio is unlocked and handle load errors
- call `soundManager.unlock()` when starting or restarting the game

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881de1c712483239750504fdc9c4a66