### PR TITLE
Add rectangle-based explosion damage

### DIFF
--- a/src/Game.test.ts
+++ b/src/Game.test.ts
@@ -41,4 +41,29 @@ describe('Game projectile spawning', () => {
     game.update();
     expect(game.playerWurm.health).toBe(80);
   });
+
+  it('damages wurm when explosion overlaps but center is outside', () => {
+    const canvas = document.createElement('canvas');
+    canvas.width = 800;
+    canvas.height = 600;
+    const ctx = canvas.getContext('2d')!;
+    const game = new Game(canvas, ctx);
+
+    const explosionRadius = 5;
+    const projectile = new Projectile(
+      game.playerWurm.x - explosionRadius - 2,
+      game.playerWurm.y,
+      0,
+      0,
+      explosionRadius,
+      20,
+      explosionRadius,
+      0
+    );
+    game.projectiles.push(projectile);
+    game.currentTurnProjectiles.push(projectile);
+    vi.spyOn(game.terrain, 'isColliding').mockReturnValue(true);
+    game.update();
+    expect(game.playerWurm.health).toBe(80);
+  });
 });

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -30,6 +30,30 @@ export class Game {
     }
     return [playerX, aiX] as const;
   }
+
+  private circleIntersectsRect(
+    cx: number,
+    cy: number,
+    radius: number,
+    rectX: number,
+    rectY: number,
+    rectW: number,
+    rectH: number
+  ): boolean {
+    const distX = Math.abs(cx - (rectX + rectW / 2));
+    const distY = Math.abs(cy - (rectY + rectH / 2));
+
+    if (distX > rectW / 2 + radius) return false;
+    if (distY > rectH / 2 + radius) return false;
+
+    if (distX <= rectW / 2) return true;
+    if (distY <= rectH / 2) return true;
+
+    const dx = distX - rectW / 2;
+    const dy = distY - rectH / 2;
+    return dx * dx + dy * dy <= radius * radius;
+  }
+
   private applyExplosionDamage(
     x: number,
     y: number,
@@ -37,10 +61,17 @@ export class Game {
     damage: number
   ) {
     const damageWurm = (wurm: Wurm) => {
-      const centerX = wurm.x + wurm.width / 2;
-      const centerY = wurm.y + wurm.height / 2;
-      const distance = Math.hypot(centerX - x, centerY - y);
-      if (distance <= radius) {
+      if (
+        this.circleIntersectsRect(
+          x,
+          y,
+          radius,
+          wurm.x,
+          wurm.y,
+          wurm.width,
+          wurm.height
+        )
+      ) {
         wurm.takeDamage(damage);
       }
     };


### PR DESCRIPTION
## Summary
- check intersection with Wurm rectangle when applying explosion damage
- add test for explosion overlapping the Wurm without the center being inside

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881f42a10fc8323bf52e552478c1210