### PR TITLE
Fix grenade wall bounce

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -175,10 +175,29 @@ export class Game {
 
       if (this.terrain.isColliding(projectile.x + projectile.radius, projectile.y + projectile.radius)) {
         if (projectile.fuse > 0) {
+          const verticalCollision = this.terrain.isColliding(
+            prevX + projectile.radius,
+            projectile.y + projectile.radius
+          );
+          const horizontalCollision = this.terrain.isColliding(
+            projectile.x + projectile.radius,
+            prevY + projectile.radius
+          );
           projectile.x = prevX;
           projectile.y = prevY;
-          projectile.dy = -projectile.dy * 0.5;
-          projectile.dx *= 0.7;
+          if (horizontalCollision && !verticalCollision) {
+            projectile.dx = -projectile.dx * 0.5;
+            projectile.dy *= 0.7;
+          } else if (verticalCollision && !horizontalCollision) {
+            projectile.dy = -projectile.dy * 0.5;
+            projectile.dx *= 0.7;
+          } else if (Math.abs(projectile.dx) > Math.abs(projectile.dy)) {
+            projectile.dx = -projectile.dx * 0.5;
+            projectile.dy *= 0.7;
+          } else {
+            projectile.dy = -projectile.dy * 0.5;
+            projectile.dx *= 0.7;
+          }
         } else {
           this.terrain.destroy(
             projectile.x + projectile.radius,

--- a/src/GameTerrainWallBounce.test.ts
+++ b/src/GameTerrainWallBounce.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Game } from './Game.js';
+import { Projectile } from './Projectile.js';
+
+vi.mock('kontra/kontra.mjs', async () => {
+  const mod = await import('./kontra.mock.js');
+  return { default: { Sprite: mod.MockSprite, GameObject: mod.MockGameObject, init: mod.init } };
+});
+
+describe('Projectile terrain wall behavior', () => {
+  it('bounces off a vertical terrain wall', () => {
+    const canvas = document.createElement('canvas');
+    canvas.width = 800;
+    canvas.height = 600;
+    const ctx = canvas.getContext('2d')!;
+    const game = new Game(canvas, ctx);
+
+    const projectile = new Projectile(94, 100, 2, 0, 5, 0, 0, 1);
+    game.projectiles.push(projectile);
+    game.currentTurnProjectiles.push(projectile);
+
+    vi.spyOn(game.terrain, 'isColliding').mockImplementation((x: number) => x >= 100);
+
+    game.update();
+
+    expect(projectile.dx).toBe(-1);
+    expect(projectile.dy).toBe(0);
+    expect(game.projectiles.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- allow bouncing from vertical terrain surfaces
- test bouncing from vertical terrain walls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881f546c24c8323a6f4049dee3d76ff