### PR TITLE
Add keyboard controls

### DIFF
--- a/src/KeyboardControls.test.ts
+++ b/src/KeyboardControls.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { setupKeyboardControls } from './KeyboardControls.js';
+
+function createInputs() {
+  const angle = document.createElement('input');
+  angle.type = 'range';
+  angle.min = '0';
+  angle.max = '180';
+  angle.step = '1';
+  angle.value = '90';
+
+  const power = document.createElement('input');
+  power.type = 'range';
+  power.min = '0';
+  power.max = '100';
+  power.step = '1';
+  power.value = '50';
+
+  const button = document.createElement('button');
+
+  return { angle, power, button };
+}
+
+describe('setupKeyboardControls', () => {
+  it('adjusts inputs and fires on key presses', () => {
+    const { angle, power, button } = createInputs();
+    let fired = false;
+    button.addEventListener('click', () => {
+      fired = true;
+    });
+
+    const remove = setupKeyboardControls({
+      angleInput: angle,
+      powerInput: power,
+      fireButton: button,
+      isPlanning: () => true,
+    });
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { code: 'ArrowLeft' }));
+    expect(angle.value).toBe('89');
+    document.dispatchEvent(new KeyboardEvent('keydown', { code: 'ArrowRight' }));
+    expect(angle.value).toBe('90');
+    document.dispatchEvent(new KeyboardEvent('keydown', { code: 'ArrowUp' }));
+    expect(power.value).toBe('51');
+    document.dispatchEvent(new KeyboardEvent('keydown', { code: 'ArrowDown' }));
+    expect(power.value).toBe('50');
+    document.dispatchEvent(new KeyboardEvent('keydown', { code: 'Space' }));
+    expect(fired).toBe(true);
+
+    remove();
+  });
+});

--- a/src/KeyboardControls.ts
+++ b/src/KeyboardControls.ts
@@ -1,0 +1,46 @@
+export interface KeyboardControlOptions {
+  angleInput: HTMLInputElement;
+  powerInput: HTMLInputElement;
+  fireButton: HTMLButtonElement;
+  isPlanning: () => boolean;
+}
+
+export function setupKeyboardControls({
+  angleInput,
+  powerInput,
+  fireButton,
+  isPlanning,
+}: KeyboardControlOptions): () => void {
+  const handler = (e: KeyboardEvent) => {
+    if (!isPlanning()) return;
+    switch (e.code) {
+      case 'ArrowLeft':
+        e.preventDefault();
+        angleInput.stepDown();
+        angleInput.dispatchEvent(new Event('input'));
+        break;
+      case 'ArrowRight':
+        e.preventDefault();
+        angleInput.stepUp();
+        angleInput.dispatchEvent(new Event('input'));
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        powerInput.stepUp();
+        powerInput.dispatchEvent(new Event('input'));
+        break;
+      case 'ArrowDown':
+        e.preventDefault();
+        powerInput.stepDown();
+        powerInput.dispatchEvent(new Event('input'));
+        break;
+      case 'Space':
+        e.preventDefault();
+        fireButton.click();
+        break;
+    }
+  };
+
+  document.addEventListener('keydown', handler);
+  return () => document.removeEventListener('keydown', handler);
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ import { WEAPON_CHOICES } from './ai/ActionSpace.js';
 import { weaponProperties } from './WeaponProperties.js';
 import { SoundManager } from './SoundManager.js';
 import { Explosion } from './Explosion.js';
+import { setupKeyboardControls } from './KeyboardControls.js';
 
 // Sound Manager
 const soundManager = new SoundManager();
@@ -111,6 +112,13 @@ function startGame(seed?: number) {
     }
   });
 
+  const removeKeyboard = setupKeyboardControls({
+    angleInput,
+    powerInput,
+    fireButton,
+    isPlanning: () => currentGameState === GameState.PLANNING && whoseTurn === 'player',
+  });
+
   mainGameLoop = GameLoop({
     update: () => {
       playerWurm.update(terrain);
@@ -187,6 +195,7 @@ function startGame(seed?: number) {
           gameScreen.style.display = 'none';
           gameOverScreen.style.display = 'flex';
           mainGameLoop.stop(); // Stop the main game loop
+          removeKeyboard();
           break;
       }
     },


### PR DESCRIPTION
## Summary
- introduce `KeyboardControls` helper with arrow key & spacebar actions
- wire keyboard controls into the main game
- remove controls when game ends
- test keyboard control behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881f60516648323b98edbb473402758