### PR TITLE
Use trained model in AI demo

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -120,7 +120,7 @@ export class Game {
     const { radius, damage, explosionRadius, fuse } = weaponProperties[weapon];
     const radians = angle * Math.PI / 180;
     wurm.barrelAngle = angle;
-    const offset = wurm.width / 2 + radius + 0.1;
+    const offset = wurm.width / 2 + radius + 5;
     const startX = wurm.x + wurm.width / 2 + Math.cos(radians) * offset - radius;
     const startY = wurm.y + wurm.height / 2 - Math.sin(radians) * offset - radius;
     const velX = power * Math.cos(radians) * 0.15;


### PR DESCRIPTION
## Summary
- load the DQN model for the start screen demo
- use model predictions when AI demo worms take a turn
- offset projectile spawn point further to avoid self-collisions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881f9cc2960832392af7392c2c85e36