### PR TITLE
Fix resize freeze

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -154,6 +154,7 @@ function startGame(seed?: number, playerIsAI = false, showUI = true) {
   }
 
   mainGameLoop = GameLoop({
+    blur: true,
     update: () => {
       playerWurm.update(terrain);
       aiWurm.update(terrain);


### PR DESCRIPTION
## Summary
- keep GameLoop active even when window loses focus

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68821b8ed5fc8323a0233ccdbc6ab6eb