### PR TITLE
Fix memory leaks in DQN prediction

### DIFF
--- a/src/ai/DQNModel.ts
+++ b/src/ai/DQNModel.ts
@@ -52,12 +52,26 @@ export class DQNModel {
     return tf.tensor2d(data, [observations.length, this.inputShape[0]]);
   }
 
+  /**
+   * Predict Q-values for a single observation.
+   *
+   * @remarks The returned tensor must be disposed by the caller.
+   */
   public predict(observation: Observation): tf.Tensor<tf.Rank> {
-    return this.model.predict(this.encode(observation)) as tf.Tensor<tf.Rank>;
+    return tf.tidy(() =>
+      this.model.predict(this.encode(observation)) as tf.Tensor<tf.Rank>
+    );
   }
 
+  /**
+   * Predict Q-values for a batch of observations.
+   *
+   * @remarks The returned tensor must be disposed by the caller.
+   */
   public predictBatch(observations: Observation[]): tf.Tensor {
-    return this.model.predict(this.encodeBatch(observations)) as tf.Tensor;
+    return tf.tidy(() =>
+      this.model.predict(this.encodeBatch(observations)) as tf.Tensor
+    );
   }
 
   public train(observation: Observation, target: tf.Tensor<tf.Rank>) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,7 +39,10 @@ function getAiAction(
   if (model) {
     const observation = getObservation(shooter, target, terrain);
     const prediction = model.predict(observation);
-    const actionIndex = prediction.argMax(-1).dataSync()[0];
+    const argMax = prediction.argMax(-1);
+    const actionIndex = argMax.dataSync()[0];
+    argMax.dispose();
+    prediction.dispose();
 
     const weaponIndex = Math.floor(actionIndex / (10 * 10));
     const angleBin = Math.floor((actionIndex % 100) / 10);


### PR DESCRIPTION
## Summary
- tidy DQNModel predictions so encoded tensors are freed
- dispose prediction results in training and main game loop

## Testing
- `npm test`
- `npm run train 1`

------
https://chatgpt.com/codex/tasks/task_e_68823440143483239c211d384f24b271