### PR TITLE
Fix: manage tensors in DQN predictions

### DIFF
--- a/src/ai/DQNModel.ts
+++ b/src/ai/DQNModel.ts
@@ -56,12 +56,24 @@ export class DQNModel {
     return tf.tensor2d(data, [observations.length, this.inputShape[0]]);
   }
 
+  /**
+   * Predict Q-values for a single observation.
+   * The caller is responsible for disposing the returned tensor.
+   */
   public predict(observation: Observation): tf.Tensor<tf.Rank> {
-    return this.model.predict(this.encode(observation)) as tf.Tensor<tf.Rank>;
+    return tf.tidy(() =>
+      this.model.predict(this.encode(observation)) as tf.Tensor<tf.Rank>
+    );
   }
 
+  /**
+   * Predict Q-values for a batch of observations.
+   * The caller is responsible for disposing the returned tensor.
+   */
   public predictBatch(observations: Observation[]): tf.Tensor {
-    return this.model.predict(this.encodeBatch(observations)) as tf.Tensor;
+    return tf.tidy(() =>
+      this.model.predict(this.encodeBatch(observations)) as tf.Tensor
+    );
   }
 
   public train(observation: Observation, target: tf.Tensor<tf.Rank>) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,7 +39,10 @@ function getAiAction(
   if (model) {
     const observation = getObservation(shooter, target, terrain);
     const prediction = model.predict(observation);
-    const actionIndex = prediction.argMax(-1).dataSync()[0];
+    const argMax = prediction.argMax(-1);
+    const actionIndex = argMax.dataSync()[0];
+    argMax.dispose();
+    prediction.dispose();
 
     const weaponIndex = Math.floor(actionIndex / (10 * 10));
     const angleBin = Math.floor((actionIndex % 100) / 10);

--- a/src/train.ts
+++ b/src/train.ts
@@ -75,8 +75,11 @@ async function train() {
         actionIndex = Math.floor(Math.random() * actionSpaceSize);
       } else {
         // Exploit: choose best action from model prediction
-        actionIndex = tf.argMax(qValues).dataSync()[0];
+        const argMax = tf.argMax(qValues);
+        actionIndex = argMax.dataSync()[0];
+        argMax.dispose();
       }
+      qValues.dispose();
 
       // Convert actionIndex back to weapon, angle, power
       const weaponIdx = Math.floor(actionIndex / (10 * 10));
@@ -128,12 +131,16 @@ async function train() {
         const batch = replayBuffer.sample(batchSize);
         const obsBatch = batch.map((b) => b.observation);
         const nextObsBatch = batch.map((b) => b.nextObservation);
-        const qCurr = (dqnModel.predictBatch(obsBatch) as tf.Tensor2D).arraySync() as number[][];
+        const qCurrTensor = dqnModel.predictBatch(obsBatch) as tf.Tensor2D;
+        const qCurr = qCurrTensor.arraySync() as number[][];
+        qCurrTensor.dispose();
         const flatQ = qCurr.flat();
         const qMax = Math.max(...flatQ);
         const qMin = Math.min(...flatQ);
         console.log(`Q range: ${qMin.toFixed(4)} to ${qMax.toFixed(4)}`);
-        const qNext = (targetModel.predictBatch(nextObsBatch) as tf.Tensor2D).arraySync() as number[][];
+        const qNextTensor = targetModel.predictBatch(nextObsBatch) as tf.Tensor2D;
+        const qNext = qNextTensor.arraySync() as number[][];
+        qNextTensor.dispose();
         for (let i = 0; i < batch.length; i++) {
           const { action, reward: r, done: d } = batch[i];
           if (d) {


### PR DESCRIPTION
## Summary
- manage tensor lifecycle in `DQNModel.predict` and `predictBatch`
- dispose tensors when using predictions in training and gameplay

## Testing
- `npm test`
- `npm run train 1`


------
https://chatgpt.com/codex/tasks/task_e_68823564766c832391bb008855a27414