### PR TITLE
Remove health sensors

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -54,7 +54,6 @@ We will use a library like TensorFlow.js. A policy-based method like Proximal Po
 The input to the RL model at each step. This needs to represent the game state concisely. It could include:
 *   Position of the AI's wurm.
 *   Position of the enemy wurm.
-*   Health of both wurms.
 *   A simplified representation of the terrain (e.g., a down-sampled grid around the wurms).
 *   Available weapons.
 

--- a/src/ai/DQNModel.ts
+++ b/src/ai/DQNModel.ts
@@ -34,10 +34,8 @@ export class DQNModel {
     const flatObservation = [
       observation.playerWurmX,
       observation.playerWurmY,
-      observation.playerWurmHealth,
       observation.aiWurmX,
       observation.aiWurmY,
-      observation.aiWurmHealth,
       ...observation.terrainHeights,
     ];
     return tf.tensor2d([flatObservation], [1, this.inputShape[0]]);
@@ -47,10 +45,8 @@ export class DQNModel {
     const data = observations.map((obs) => [
       obs.playerWurmX,
       obs.playerWurmY,
-      obs.playerWurmHealth,
       obs.aiWurmX,
       obs.aiWurmY,
-      obs.aiWurmHealth,
       ...obs.terrainHeights,
     ]);
     return tf.tensor2d(data, [observations.length, this.inputShape[0]]);

--- a/src/ai/ObservationSpace.ts
+++ b/src/ai/ObservationSpace.ts
@@ -4,10 +4,8 @@ import { Terrain } from '../Terrain.js';
 export interface Observation {
   playerWurmX: number;
   playerWurmY: number;
-  playerWurmHealth: number;
   aiWurmX: number;
   aiWurmY: number;
-  aiWurmHealth: number;
   // Simplified terrain representation (e.g., heights at intervals)
   terrainHeights: number[];
 }
@@ -31,10 +29,8 @@ export function getObservation(playerWurm: Wurm, aiWurm: Wurm, terrain: Terrain)
   return {
     playerWurmX: playerWurm.x,
     playerWurmY: playerWurm.y,
-    playerWurmHealth: playerWurm.health,
     aiWurmX: aiWurm.x,
     aiWurmY: aiWurm.y,
-    aiWurmHealth: aiWurm.health,
     terrainHeights,
   };
 }

--- a/src/ai/ReplayBuffer.test.ts
+++ b/src/ai/ReplayBuffer.test.ts
@@ -4,10 +4,8 @@ import { ReplayBuffer, Experience } from './ReplayBuffer.js';
 const dummyObs = {
   playerWurmX: 0,
   playerWurmY: 0,
-  playerWurmHealth: 100,
   aiWurmX: 0,
   aiWurmY: 0,
-  aiWurmHealth: 100,
   terrainHeights: [0],
 };
 

--- a/src/train.ts
+++ b/src/train.ts
@@ -36,7 +36,7 @@ function getDummyPlayerShot() {
 }
 
 // DQN Model setup
-const observationSpaceSize = 6 + canvas.width / 20;
+const observationSpaceSize = 4 + canvas.width / 20;
 const actionSpaceSize = WEAPON_CHOICES.length * 10 * 10;
 const dqnModel = new DQNModel([observationSpaceSize], actionSpaceSize);
 const targetModel = new DQNModel([observationSpaceSize], actionSpaceSize);


### PR DESCRIPTION
## Summary
- drop health metrics from ObservationSpace
- clean up DQNModel to match observation changes
- adjust replay buffer test data
- tweak training observation space size
- update plan docs

## Testing
- `npm test`
- `npm run train 1`


------
https://chatgpt.com/codex/tasks/task_e_68824ab1c0488323a092d6b37b4b4dcb