### PR TITLE
Remove terrain from AI observation

### DIFF
--- a/src/ai/DQNModel.ts
+++ b/src/ai/DQNModel.ts
@@ -36,7 +36,6 @@ export class DQNModel {
       observation.playerWurmY,
       observation.aiWurmX,
       observation.aiWurmY,
-      ...observation.terrainHeights,
     ];
     return tf.tensor2d([flatObservation], [1, this.inputShape[0]]);
   }
@@ -47,7 +46,6 @@ export class DQNModel {
       obs.playerWurmY,
       obs.aiWurmX,
       obs.aiWurmY,
-      ...obs.terrainHeights,
     ]);
     return tf.tensor2d(data, [observations.length, this.inputShape[0]]);
   }

--- a/src/ai/ObservationSpace.ts
+++ b/src/ai/ObservationSpace.ts
@@ -1,36 +1,17 @@
 import { Wurm } from '../Wurm.js';
-import { Terrain } from '../Terrain.js';
 
 export interface Observation {
   playerWurmX: number;
   playerWurmY: number;
   aiWurmX: number;
   aiWurmY: number;
-  // Simplified terrain representation (e.g., heights at intervals)
-  terrainHeights: number[];
 }
 
-export function getObservation(playerWurm: Wurm, aiWurm: Wurm, terrain: Terrain): Observation {
-  const terrainHeights: number[] = [];
-  // Sample terrain heights at regular intervals
-  const interval = 20; // Sample every 20 pixels
-  for (let x = 0; x < terrain.width; x += interval) {
-    // Find the highest point of the terrain at this x-coordinate
-    let highestY = terrain.height;
-    for (let y = 0; y < terrain.height; y++) {
-      if (terrain.isColliding(x, y)) {
-        highestY = y;
-        break;
-      }
-    }
-    terrainHeights.push(highestY);
-  }
-
+export function getObservation(playerWurm: Wurm, aiWurm: Wurm): Observation {
   return {
     playerWurmX: playerWurm.x,
     playerWurmY: playerWurm.y,
     aiWurmX: aiWurm.x,
     aiWurmY: aiWurm.y,
-    terrainHeights,
   };
 }

--- a/src/ai/ReplayBuffer.test.ts
+++ b/src/ai/ReplayBuffer.test.ts
@@ -6,7 +6,6 @@ const dummyObs = {
   playerWurmY: 0,
   aiWurmX: 0,
   aiWurmY: 0,
-  terrainHeights: [0],
 };
 
 describe('ReplayBuffer', () => {

--- a/src/eval.ts
+++ b/src/eval.ts
@@ -21,7 +21,7 @@ canvas.height = 600;
 init(canvas);
 
 const game = new Game(canvas, canvas.getContext('2d')!);
-const { playerWurm, aiWurm, terrain } = game;
+const { playerWurm, aiWurm } = game;
 
 function getDummyPlayerShot() {
   const weapon = WEAPON_CHOICES[Math.floor(Math.random() * WEAPON_CHOICES.length)];
@@ -41,7 +41,7 @@ async function evaluate(numEpisodes = 1) {
     let prevDistance = Math.abs(aiWurm.x - playerWurm.x);
 
     while (!done) {
-      const observation = getObservation(aiWurm, playerWurm, terrain);
+      const observation = getObservation(aiWurm, playerWurm);
       const qValues = model.predict(observation) as tf.Tensor;
       const argMax = tf.argMax(qValues);
       const actionIndex = argMax.dataSync()[0];

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,6 @@
 // Import kontra from its ESM build for compatibility with both browser and Node
 import kontra from 'kontra/kontra.mjs';
 const { init, GameLoop } = kontra;
-import { Terrain } from './Terrain.js';
 import { Wurm } from './Wurm.js';
 import { Game } from './Game.js';
 import { DQNModel } from './ai/DQNModel.js';
@@ -29,7 +28,6 @@ const playAgainButton = document.getElementById('play-again-button') as HTMLButt
 function getAiAction(
   shooter: Wurm,
   target: Wurm,
-  terrain: Terrain,
   model: DQNModel | null
 ) {
   let aiAngle: number;
@@ -37,7 +35,7 @@ function getAiAction(
   let aiWeapon: string;
 
   if (model) {
-    const observation = getObservation(shooter, target, terrain);
+    const observation = getObservation(shooter, target);
     const prediction = model.predict(observation);
     const argMax = prediction.argMax(-1);
     const actionIndex = argMax.dataSync()[0];
@@ -173,7 +171,6 @@ function startGame(seed?: number, playerIsAI = false, showUI = true) {
             const { aiWeapon, aiAngle, aiPower } = getAiAction(
               playerWurm,
               aiWurm,
-              terrain,
               aiModel
             );
             game.fire(playerWurm, aiWeapon, aiAngle, aiPower);
@@ -212,7 +209,6 @@ function startGame(seed?: number, playerIsAI = false, showUI = true) {
           const { aiWeapon, aiAngle, aiPower } = getAiAction(
             aiWurm,
             playerWurm,
-            terrain,
             aiModel
           );
           game.fire(aiWurm, aiWeapon, aiAngle, aiPower);

--- a/src/train.ts
+++ b/src/train.ts
@@ -26,7 +26,7 @@ init(canvas);
 
 // Game setup using shared Game class
 const game = new Game(canvas, canvas.getContext('2d')!);
-const { playerWurm, aiWurm, terrain } = game;
+const { playerWurm, aiWurm } = game;
 
 function getDummyPlayerShot() {
   const weapon = WEAPON_CHOICES[Math.floor(Math.random() * WEAPON_CHOICES.length)];
@@ -36,7 +36,7 @@ function getDummyPlayerShot() {
 }
 
 // DQN Model setup
-const observationSpaceSize = 4 + canvas.width / 20;
+const observationSpaceSize = 4;
 const actionSpaceSize = WEAPON_CHOICES.length * 10 * 10;
 const dqnModel = new DQNModel([observationSpaceSize], actionSpaceSize);
 const targetModel = new DQNModel([observationSpaceSize], actionSpaceSize);
@@ -71,7 +71,7 @@ async function train() {
     let episodeLossCount = 0;
 
     while (!done) {
-      const observation = getObservation(aiWurm, playerWurm, terrain);
+      const observation = getObservation(aiWurm, playerWurm);
       const qValues = dqnModel.predict(observation);
       const qArr = (qValues.arraySync() as number[][])[0];
       const stepQMin = Math.min(...qArr);
@@ -110,7 +110,7 @@ async function train() {
 
       game.simulateUntilProjectilesResolve();
 
-      const nextObservation = getObservation(aiWurm, playerWurm, terrain);
+      const nextObservation = getObservation(aiWurm, playerWurm);
       const newDistance = Math.abs(aiWurm.x - playerWurm.x);
       const distanceDelta = newDistance - prevDistance;
       prevDistance = newDistance;


### PR DESCRIPTION
## Summary
- simplify observation space by removing terrain heights
- update DQN model encoding for new observation space
- adjust training and evaluation scripts
- fix AI input function usage
- update tests for new observation structure

## Testing
- `npm test`
- `npm run train 1`


------
https://chatgpt.com/codex/tasks/task_e_68826662d81c832385f931adfecaaf2b