### PR TITLE
Update observation space for AI

### DIFF
--- a/src/ai/DQNModel.ts
+++ b/src/ai/DQNModel.ts
@@ -32,20 +32,16 @@ export class DQNModel {
 
   private encode(observation: Observation): tf.Tensor2D {
     const flatObservation = [
-      observation.playerWurmX,
-      observation.playerWurmY,
-      observation.aiWurmX,
-      observation.aiWurmY,
+      observation.angleToTarget,
+      observation.distanceToTarget,
     ];
     return tf.tensor2d([flatObservation], [1, this.inputShape[0]]);
   }
 
   private encodeBatch(observations: Observation[]): tf.Tensor2D {
     const data = observations.map((obs) => [
-      obs.playerWurmX,
-      obs.playerWurmY,
-      obs.aiWurmX,
-      obs.aiWurmY,
+      obs.angleToTarget,
+      obs.distanceToTarget,
     ]);
     return tf.tensor2d(data, [observations.length, this.inputShape[0]]);
   }

--- a/src/ai/ObservationSpace.ts
+++ b/src/ai/ObservationSpace.ts
@@ -1,17 +1,18 @@
 import { Wurm } from '../Wurm.js';
 
 export interface Observation {
-  playerWurmX: number;
-  playerWurmY: number;
-  aiWurmX: number;
-  aiWurmY: number;
+  angleToTarget: number;
+  distanceToTarget: number;
 }
 
 export function getObservation(playerWurm: Wurm, aiWurm: Wurm): Observation {
+  const dx = playerWurm.x - aiWurm.x;
+  const dy = playerWurm.y - aiWurm.y;
+  const angleToTarget = (Math.atan2(dy, dx) * 180) / Math.PI;
+  const distanceToTarget = Math.hypot(dx, dy);
+
   return {
-    playerWurmX: playerWurm.x,
-    playerWurmY: playerWurm.y,
-    aiWurmX: aiWurm.x,
-    aiWurmY: aiWurm.y,
+    angleToTarget,
+    distanceToTarget,
   };
 }

--- a/src/ai/ReplayBuffer.test.ts
+++ b/src/ai/ReplayBuffer.test.ts
@@ -2,10 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { ReplayBuffer, Experience } from './ReplayBuffer.js';
 
 const dummyObs = {
-  playerWurmX: 0,
-  playerWurmY: 0,
-  aiWurmX: 0,
-  aiWurmY: 0,
+  angleToTarget: 0,
+  distanceToTarget: 0,
 };
 
 describe('ReplayBuffer', () => {

--- a/src/train.ts
+++ b/src/train.ts
@@ -36,7 +36,7 @@ function getDummyPlayerShot() {
 }
 
 // DQN Model setup
-const observationSpaceSize = 4;
+const observationSpaceSize = 2;
 const actionSpaceSize = WEAPON_CHOICES.length * 10 * 10;
 const dqnModel = new DQNModel([observationSpaceSize], actionSpaceSize);
 const targetModel = new DQNModel([observationSpaceSize], actionSpaceSize);


### PR DESCRIPTION
## Summary
- simplify AI observation space to use just angle and distance
- update DQN model encoding for new observation structure
- fix ReplayBuffer tests
- adjust training setup to match updated observation size

## Testing
- `npm test`
- `npm run train 1`


------
https://chatgpt.com/codex/tasks/task_e_68828930233883239c5971ea101939db