### PR TITLE
Fix observation order to improve AI

### DIFF
--- a/src/ai/ObservationSpace.ts
+++ b/src/ai/ObservationSpace.ts
@@ -5,6 +5,8 @@ export interface Observation {
   distanceToTarget: number;
 }
 
+// Note: "playerWurm" is the target and "aiWurm" is the observer.
+// The observation describes the position of the target relative to the AI.
 export function getObservation(playerWurm: Wurm, aiWurm: Wurm): Observation {
   const dx = playerWurm.x - aiWurm.x;
   const dy = playerWurm.y - aiWurm.y;

--- a/src/eval.ts
+++ b/src/eval.ts
@@ -41,7 +41,7 @@ async function evaluate(numEpisodes = 1) {
     let prevDistance = Math.abs(aiWurm.x - playerWurm.x);
 
     while (!done) {
-      const observation = getObservation(aiWurm, playerWurm);
+      const observation = getObservation(playerWurm, aiWurm);
       const qValues = model.predict(observation) as tf.Tensor;
       const argMax = tf.argMax(qValues);
       const actionIndex = argMax.dataSync()[0];

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,7 +35,7 @@ function getAiAction(
   let aiWeapon: string;
 
   if (model) {
-    const observation = getObservation(shooter, target);
+    const observation = getObservation(target, shooter);
     const prediction = model.predict(observation);
     const argMax = prediction.argMax(-1);
     const actionIndex = argMax.dataSync()[0];

--- a/src/train.ts
+++ b/src/train.ts
@@ -71,7 +71,7 @@ async function train() {
     let episodeLossCount = 0;
 
     while (!done) {
-      const observation = getObservation(aiWurm, playerWurm);
+      const observation = getObservation(playerWurm, aiWurm);
       const qValues = dqnModel.predict(observation);
       const qArr = (qValues.arraySync() as number[][])[0];
       const stepQMin = Math.min(...qArr);
@@ -110,7 +110,7 @@ async function train() {
 
       game.simulateUntilProjectilesResolve();
 
-      const nextObservation = getObservation(aiWurm, playerWurm);
+      const nextObservation = getObservation(playerWurm, aiWurm);
       const newDistance = Math.abs(aiWurm.x - playerWurm.x);
       const distanceDelta = newDistance - prevDistance;
       prevDistance = newDistance;


### PR DESCRIPTION
## Summary
- fix order of arguments when getting observations so AI sees the correct perspective
- adjust usage in training, evaluation and main game
- clarify ObservationSpace argument order

## Testing
- `npm test`
- `npm run train 1`
- `npm run train 20`
- `npm run eval 10`


------
https://chatgpt.com/codex/tasks/task_e_688315f8a18883239cfa30b1ac0fc327