### PR TITLE
Fix training instability with normalized observations

### DIFF
--- a/src/ai/ObservationSpace.ts
+++ b/src/ai/ObservationSpace.ts
@@ -1,9 +1,17 @@
 import { Wurm } from '../Wurm.js';
 
 export interface Observation {
+  /**
+   * Normalized angle from the AI Wurm to the player Wurm in the range [-1, 1].
+   */
   angleToTarget: number;
+  /**
+   * Normalized distance from the AI Wurm to the player Wurm in the range [0, 1].
+   */
   distanceToTarget: number;
 }
+
+const MAX_DISTANCE = 1000;
 
 export function getObservation(playerWurm: Wurm, aiWurm: Wurm): Observation {
   const dx = playerWurm.x - aiWurm.x;
@@ -12,7 +20,7 @@ export function getObservation(playerWurm: Wurm, aiWurm: Wurm): Observation {
   const distanceToTarget = Math.hypot(dx, dy);
 
   return {
-    angleToTarget,
-    distanceToTarget,
+    angleToTarget: angleToTarget / 180,
+    distanceToTarget: Math.min(distanceToTarget, MAX_DISTANCE) / MAX_DISTANCE,
   };
 }


### PR DESCRIPTION
## Summary
- normalize angle and distance in `getObservation`
- clip distance so DQN model sees values 0..1

## Testing
- `npm test`
- `npm run train 1`
- `npm run train 50`
- `npm run eval 10`


------
https://chatgpt.com/codex/tasks/task_e_688316fbb4b4832391c74ec20001c292