### PR TITLE
Randomize spawn during training

### DIFF
--- a/src/Game.ts
+++ b/src/Game.ts
@@ -32,6 +32,20 @@ export class Game {
     return [playerX, aiX] as const;
   }
 
+  public randomizeSpawnPositions() {
+    const [playerX, aiX] = this.getSpawnPositions();
+    this.playerWurm.x = playerX;
+    this.playerWurm.y =
+      this.terrain.getGroundHeight(playerX) -
+      this.spawnOffset -
+      this.playerWurm.height;
+    this.aiWurm.x = aiX;
+    this.aiWurm.y =
+      this.terrain.getGroundHeight(aiX) -
+      this.spawnOffset -
+      this.aiWurm.height;
+  }
+
   private circleIntersectsRect(
     cx: number,
     cy: number,
@@ -115,14 +129,8 @@ export class Game {
       this.context,
       this.mapSeed
     );
-    const [playerX, aiX] = this.getSpawnPositions();
-    this.playerWurm.x = playerX;
-    this.playerWurm.y =
-      this.terrain.getGroundHeight(playerX) - this.spawnOffset - this.playerWurm.height;
+    this.randomizeSpawnPositions();
     this.playerWurm.health = 100;
-    this.aiWurm.x = aiX;
-    this.aiWurm.y =
-      this.terrain.getGroundHeight(aiX) - this.spawnOffset - this.aiWurm.height;
     this.aiWurm.health = 100;
     this.projectiles = [];
     this.currentTurnProjectiles = [];

--- a/src/train.ts
+++ b/src/train.ts
@@ -59,6 +59,7 @@ async function train() {
   for (let episode = 0; episode < numEpisodes; episode++) {
     // Reset game state for new episode
     game.reset();
+    game.randomizeSpawnPositions();
 
     let done = false;
     let totalReward = 0;


### PR DESCRIPTION
## Summary
- add `randomizeSpawnPositions` helper
- use it in `Game.reset`
- call it from the training loop

## Testing
- `npm test`
- `npm run train 1`


------
https://chatgpt.com/codex/tasks/task_e_68831a827b2083239380e10e780eeb7a