### PR TITLE
Add head to wurm drawing

### DIFF
--- a/src/Wurm.ts
+++ b/src/Wurm.ts
@@ -22,8 +22,23 @@ export class Wurm extends Sprite {
   }
 
   public draw = () => {
+    // body with outline
     this.context.fillStyle = this.color;
-    this.context.fillRect(this.x, this.y, this.width, this.height);
+    this.context.strokeStyle = 'black';
+    this.context.lineWidth = 2;
+    this.context.beginPath();
+    this.context.rect(this.x, this.y, this.width, this.height);
+    this.context.fill();
+    this.context.stroke();
+
+    // head at the bottom of the body
+    const headRadius = this.height / 2;
+    const headX = this.x + this.width / 2;
+    const headY = this.y + this.height + headRadius;
+    this.context.beginPath();
+    this.context.arc(headX, headY, headRadius, 0, Math.PI * 2);
+    this.context.fill();
+    this.context.stroke();
 
     // barrel showing current angle
     const centerX = this.x + this.width / 2;


### PR DESCRIPTION
## Summary
- draw the wurm body with a black outline
- add a round head at the bottom of the body

## Testing
- `npm test`
- `npm run train 1`


------
https://chatgpt.com/codex/tasks/task_e_68831f69b0bc8323b89bb2f5382bd871