### PR TITLE
Use fixed seed

### DIFF
--- a/src/eval.ts
+++ b/src/eval.ts
@@ -1,6 +1,7 @@
 import { JSDOM } from 'jsdom';
 import * as tf from '@tensorflow/tfjs-core';
 import '@tensorflow/tfjs-node';
+import seedrandom from 'seedrandom';
 
 import { init } from './kontra.mock.js';
 import { Game } from './Game.js';
@@ -14,6 +15,7 @@ const dom = new JSDOM(`<!DOCTYPE html><body><canvas id="game"></canvas></body>`)
 (global as any).document = dom.window.document;
 (global as any).HTMLCanvasElement = dom.window.HTMLCanvasElement;
 (global as any).Image = dom.window.Image;
+seedrandom('42', { global: true });
 
 const canvas = dom.window.document.getElementById('game') as HTMLCanvasElement;
 canvas.width = 800;

--- a/src/seedrandom.d.ts
+++ b/src/seedrandom.d.ts
@@ -1,0 +1,1 @@
+declare module 'seedrandom';

--- a/src/train.ts
+++ b/src/train.ts
@@ -2,6 +2,7 @@ import { JSDOM } from 'jsdom';
 import * as tf from '@tensorflow/tfjs-core';
 import '@tensorflow/tfjs-node'; // Use tfjs-node for headless environment
 import { promises as fs } from 'fs';
+import seedrandom from 'seedrandom';
 
 import { init } from './kontra.mock.js';
 import { Game } from './Game.js';
@@ -17,6 +18,7 @@ const dom = new JSDOM(`<!DOCTYPE html><body><canvas id="game"></canvas></body>`)
 (global as any).document = dom.window.document;
 (global as any).HTMLCanvasElement = dom.window.HTMLCanvasElement;
 (global as any).Image = dom.window.Image;
+seedrandom('42', { global: true });
 
 const canvas = dom.window.document.getElementById('game') as HTMLCanvasElement;
 canvas.width = 800;


### PR DESCRIPTION
## Summary
- use seedrandom to fix Math.random output
- expose `seedrandom` types

## Testing
- `npm test`
- `npm run train 1`


------
https://chatgpt.com/codex/tasks/task_e_68832d4029888323bd436a34d33d2de0