### PR TITLE
Fix evaluation hang

### DIFF
--- a/src/eval.ts
+++ b/src/eval.ts
@@ -42,8 +42,10 @@ async function evaluate(numEpisodes = 1) {
     let episodeReward = 0;
     let prevDistance = Math.abs(aiWurm.x - playerWurm.x);
     let whoseTurn: 'player' | 'ai' = 'player';
+    let steps = 0;
+    const maxSteps = 200;
 
-    while (!done) {
+    while (!done && steps < maxSteps) {
       const prevAiHealth = aiWurm.health;
       const prevPlayerHealth = playerWurm.health;
 
@@ -95,6 +97,11 @@ async function evaluate(numEpisodes = 1) {
       } else {
         whoseTurn = whoseTurn === 'ai' ? 'player' : 'ai';
       }
+      steps++;
+    }
+
+    if (steps >= maxSteps) {
+      console.log(`Episode ${episode + 1}: reached max steps`);
     }
 
     console.log(`Episode ${episode + 1}: Reward = ${episodeReward}`);


### PR DESCRIPTION
## Summary
- prevent infinite evaluation episodes by capping step count

## Testing
- `npm test`
- `npm run train 1`
- `npm run eval 10`

------
https://chatgpt.com/codex/tasks/task_e_688330c74594832394a3b2ab68f0eee3