### PR TITLE
Improve determinism in training and eval

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@tensorflow/tfjs-node": "^4.22.0",
         "canvas": "^3.1.2",
         "kontra": "^10.0.2",
+        "seedrandom": "^3.0.5",
         "typescript": "^5.8.3",
         "vite": "^7.0.5"
       },

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@tensorflow/tfjs-node": "^4.22.0",
     "canvas": "^3.1.2",
     "kontra": "^10.0.2",
+    "seedrandom": "^3.0.5",
     "typescript": "^5.8.3",
     "vite": "^7.0.5"
   },

--- a/src/eval.ts
+++ b/src/eval.ts
@@ -1,6 +1,7 @@
 import { JSDOM } from 'jsdom';
 import * as tf from '@tensorflow/tfjs-core';
 import '@tensorflow/tfjs-node';
+import seedrandom from 'seedrandom';
 
 import { init } from './kontra.mock.js';
 import { Game } from './Game.js';
@@ -14,7 +15,8 @@ const dom = new JSDOM(`<!DOCTYPE html><body><canvas id="game"></canvas></body>`)
 (global as any).document = dom.window.document;
 (global as any).HTMLCanvasElement = dom.window.HTMLCanvasElement;
 (global as any).Image = dom.window.Image;
-const seed = 123;
+const seed = parseInt(process.argv[3] || '123');
+seedrandom(seed.toString(), { global: true });
 
 const canvas = dom.window.document.getElementById('game') as HTMLCanvasElement;
 canvas.width = 800;
@@ -34,6 +36,7 @@ function getDummyPlayerShot() {
 async function evaluate(numEpisodes = 1) {
   const model = await DQNModel.load('file://./src/models/dqn-model/model.json');
   let totalReward = 0;
+  console.log(`Evaluating ${numEpisodes} episodes with seed: ${seed}`);
 
   for (let episode = 0; episode < numEpisodes; episode++) {
     game.reset();

--- a/src/train.ts
+++ b/src/train.ts
@@ -2,6 +2,7 @@ import { JSDOM } from 'jsdom';
 import * as tf from '@tensorflow/tfjs-core';
 import '@tensorflow/tfjs-node'; // Use tfjs-node for headless environment
 import { promises as fs } from 'fs';
+import seedrandom from 'seedrandom';
 
 import { init } from './kontra.mock.js';
 import { Game } from './Game.js';
@@ -17,7 +18,8 @@ const dom = new JSDOM(`<!DOCTYPE html><body><canvas id="game"></canvas></body>`)
 (global as any).document = dom.window.document;
 (global as any).HTMLCanvasElement = dom.window.HTMLCanvasElement;
 (global as any).Image = dom.window.Image;
-const seed = 123;
+const seed = parseInt(process.argv[3] || '123');
+seedrandom(seed.toString(), { global: true });
 
 const canvas = dom.window.document.getElementById('game') as HTMLCanvasElement;
 canvas.width = 800;
@@ -50,7 +52,7 @@ const targetUpdateFreq = 5;
 
 // Training parameters
 const numEpisodes = parseInt(process.argv[2]) || 100;
-console.log(`Number of episodes: ${numEpisodes}`);
+console.log(`Number of episodes: ${numEpisodes}, Seed: ${seed}`);
 const epsilonDecay = 0.995;
 let epsilon = 1.0;
 const epsilonMin = 0.1;


### PR DESCRIPTION
## Summary
- add `seedrandom` dependency
- seed `Math.random` in training and evaluation scripts
- expose seed via command line arguments

## Testing
- `npm test`
- `npm run train 1`

------
https://chatgpt.com/codex/tasks/task_e_688348332e1083239fac8cf5a4d66157