### PR TITLE
Ignore player shot in reward

### DIFF
--- a/src/eval.ts
+++ b/src/eval.ts
@@ -88,8 +88,11 @@ async function evaluate(numEpisodes = 1) {
       const playerWon = aiWurm.health <= 0 && playerWurm.health > 0;
       const gameEnded = aiWon || playerWon;
 
-      const reward = calculateReward(aiWurm, playerWurm, hitEnemy, hitSelf, playerWon, aiWon, distanceDelta);
-      episodeReward += reward;
+      let reward = 0;
+      if (whoseTurn === 'ai') {
+        reward = calculateReward(aiWurm, playerWurm, hitEnemy, hitSelf, playerWon, aiWon, distanceDelta);
+        episodeReward += reward;
+      }
 
       if (gameEnded) {
         done = true;


### PR DESCRIPTION
## Summary
- ignore player damage when calculating reward during training
- skip reward calculation for player's turns during evaluation

## Testing
- `npm test`
- `npm run train 1`


------
https://chatgpt.com/codex/tasks/task_e_688352fd41ac8323b5eb9fb185a120f6