### PR TITLE
Fix: delay epsilon decay

### DIFF
--- a/src/train.ts
+++ b/src/train.ts
@@ -185,7 +185,9 @@ async function train() {
       }
     }
 
-    epsilon = Math.max(epsilonMin, epsilon * epsilonDecay);
+    if (episode >= 50) {
+      epsilon = Math.max(epsilonMin, epsilon * epsilonDecay);
+    }
     const qRangeStr = isFinite(episodeQMin) && isFinite(episodeQMax)
       ? `${episodeQMin.toFixed(4)} to ${episodeQMax.toFixed(4)}`
       : 'N/A';


### PR DESCRIPTION
## Summary
- hold epsilon constant for the first 50 training episodes

## Testing
- `npm test`
- `npm run train 1`


------
https://chatgpt.com/codex/tasks/task_e_68835df652ac8323952f272cbc6ebe97