### PR TITLE
Round up health in UI display

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -188,8 +188,16 @@ function startGame(seed?: number, playerIsAI = false, showUI = true) {
       // Display health (for debugging/testing)
       context.fillStyle = 'white';
       context.font = '16px Arial';
-      context.fillText(`Player Health: ${game.playerWurm.health}`, 10, 20);
-      context.fillText(`AI Health: ${game.aiWurm.health}`, canvas.width - 150, 20);
+      context.fillText(
+        `Player Health: ${Math.ceil(game.playerWurm.health)}`,
+        10,
+        20
+      );
+      context.fillText(
+        `AI Health: ${Math.ceil(game.aiWurm.health)}`,
+        canvas.width - 150,
+        20
+      );
     }
   } as any);
 


### PR DESCRIPTION
## Summary
- round player and AI health values when drawing on the canvas

## Testing
- `npm test`
- `npm run train 1`


------
https://chatgpt.com/codex/tasks/task_e_6883a1d9e3f0832391eb588f47bb90f7